### PR TITLE
chore(flavors): update android AGP and Kotlin versions

### DIFF
--- a/flavors/android/settings.gradle
+++ b/flavors/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.8.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
Updates AGP and Kotlin versions to fix build. Note that there are still a bunch of warnings about the updated versions being old.