### PR TITLE
fix(shorebird_runner): add cloud multi-stage Docker build and shorebird_ci coverage

### DIFF
--- a/.github/workflows/shorebird_ci.yaml
+++ b/.github/workflows/shorebird_ci.yaml
@@ -20,6 +20,7 @@ jobs:
       progressive_rollout_demo: ${{ steps.filter.outputs.progressive_rollout_demo }}
       shorebird_fintech_wallet: ${{ steps.filter.outputs.shorebird_fintech_wallet }}
       clear_skies: ${{ steps.filter.outputs.clear_skies }}
+      shorebird_runner: ${{ steps.filter.outputs.shorebird_runner }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -45,6 +46,8 @@ jobs:
               - shorebird_fintech_wallet/**
             clear_skies:
               - clear_skies/**
+            shorebird_runner:
+              - shorebird_runner/**
 
   flavors:
     needs: changes
@@ -124,6 +127,19 @@ jobs:
       flutter_version: ""
       has_integration_tests: false
 
+  shorebird_runner:
+    needs: changes
+    if: needs.changes.outputs.shorebird_runner == 'true'
+    uses: ./.github/workflows/_shorebird_ci_flutter.yaml
+    with:
+      package_name: shorebird_runner
+      package_path: shorebird_runner
+      has_bloc_lint: false
+      has_unit_tests: true
+      subpackages: ""
+      flutter_version: ""
+      has_integration_tests: false
+
   required:
     name: required
     if: ${{ always() }}
@@ -135,6 +151,7 @@ jobs:
       - progressive_rollout_demo
       - shorebird_fintech_wallet
       - clear_skies
+      - shorebird_runner
     runs-on: ubuntu-latest
     steps:
       - name: Check required jobs

--- a/shorebird_runner/Dockerfile
+++ b/shorebird_runner/Dockerfile
@@ -1,21 +1,27 @@
 # ----------------------------------------------------------------------
-# Shorebird Patch Rush — Lobby & Tournament WebSocket Server Dockerfile
-# Deployable to Railway, Render, Fly.io, or any container host
+# Shorebird Patch Rush — All-in-One Cloud Dockerfile (Render, Railway, Fly.io)
+# Builds Flutter Web Release + Dart WebSocket Server into a single image
 # ----------------------------------------------------------------------
 
-FROM dart:stable AS build
+# Stage 1: Build Flutter Web & Dart Server
+FROM ghcr.io/cirruslabs/flutter:stable AS build
 
 WORKDIR /app
 
 # Cache dependencies
 COPY pubspec.* ./
-RUN dart pub get
+RUN flutter pub get
 
-# Build native binary
+# Copy source code
 COPY . .
+
+# 1. Compile Flutter Web release
+RUN flutter build web --release
+
+# 2. Compile native Dart Lobby & Tournament server
 RUN dart compile exe bin/lobby_server.dart -o bin/server
 
-# Minimal runtime image
+# Stage 2: Minimal Runtime Image
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
1. **Cloud Multi-Stage Dockerfile**: Updates `shorebird_runner/Dockerfile` to use `ghcr.io/cirruslabs/flutter:stable` so both the Flutter Web app release and the Dart lobby server build cleanly in cloud container environments (Render, Railway, Fly.io) without requiring pre-compiled build artifacts in Git.
2. **Shorebird CI Coverage**: Adds `shorebird_runner` to `.github/workflows/shorebird_ci.yaml` (`dorny/paths-filter`, workflow job, and `required` aggregator dependencies), resolving the `shorebird_ci verify` failure.