### PR TITLE
fix(shorebird_runner): add mobile fullscreen, lane tap steering, and host-only rematch flow

### DIFF
--- a/shorebird_runner/bin/lobby_server.dart
+++ b/shorebird_runner/bin/lobby_server.dart
@@ -242,10 +242,44 @@ class LobbyManager {
       case 'leave_room':
         _handleDisconnect(socket);
         break;
+      case 'rematch':
+        _handleRematch(socket, message);
+        break;
       default:
         socket.add(
             jsonEncode({'type': 'error', 'message': 'Unknown action: $type'}));
     }
+  }
+
+  void _handleRematch(WebSocket socket, Map<String, dynamic> message) {
+    final code = socketToRoomCode[socket];
+    final pid = socketToPlayerId[socket];
+    if (code == null || !rooms.containsKey(code)) return;
+
+    final room = rooms[code]!;
+    if (room.hostId != pid) {
+      socket.add(jsonEncode({
+        'type': 'error',
+        'message': 'Only the room owner can initiate a rematch',
+      }));
+      return;
+    }
+
+    room.countdownTimer?.cancel();
+    room.state = RoomState.waiting;
+    for (final p in room.players.values) {
+      p.isAlive = true;
+      p.score = 0;
+      p.patches = 0;
+      p.level = 1;
+    }
+
+    print(
+        '🔄 Room $code: Host initiated rematch. Returning all players to lobby.');
+    room.broadcast({
+      'type': 'room_rematch',
+      'room': room.toJson(),
+    });
   }
 
   void _createRoom(WebSocket socket, Map<String, dynamic> message) {

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -264,7 +264,8 @@ class LaneWorld extends Component {
       begin: Alignment.topCenter,
       end: Alignment.bottomCenter,
       colors: [Color(0xFF0D1826), Color(0xFF040810)],
-    ).createShader(const Rect.fromLTWH(0, cy - 150, GameConfig.designWidth, 150));
+    ).createShader(
+        const Rect.fromLTWH(0, cy - 150, GameConfig.designWidth, 150));
     canvas.drawPath(_skylineBuildingsPath, _bldFillPaint);
 
     canvas.drawPath(_amberWindowsPath, _amberWinPaint);
@@ -315,9 +316,12 @@ class LaneWorld extends Component {
     const w = GameConfig.designWidth;
 
     // Billboards
-    _renderCachedBillboard(canvas, 68, cy - 120, 48, 'SHOREBIRD', const Color(0xFFFFC107));
-    _renderCachedBillboard(canvas, w - 270, cy - 145, 72, 'CODEPUSH', const Color(0xFFFFB300));
-    _renderCachedBillboard(canvas, w - 126, cy - 115, 66, 'FLUTTER', const Color(0xFF00FFCC));
+    _renderCachedBillboard(
+        canvas, 68, cy - 120, 48, 'SHOREBIRD', const Color(0xFFFFC107));
+    _renderCachedBillboard(
+        canvas, w - 270, cy - 145, 72, 'CODEPUSH', const Color(0xFFFFB300));
+    _renderCachedBillboard(
+        canvas, w - 126, cy - 115, 66, 'FLUTTER', const Color(0xFF00FFCC));
 
     // Blinking radio antennas
     _drawAntenna(canvas, 68 + 24, cy - 120, 0);
@@ -330,8 +334,7 @@ class LaneWorld extends Component {
     final bbY = topY - 14;
     final bbRect = Rect.fromLTWH(x - 2, bbY, w + 4, 12);
 
-    canvas.drawRRect(
-        RRect.fromRectAndRadius(bbRect, const Radius.circular(2)),
+    canvas.drawRRect(RRect.fromRectAndRadius(bbRect, const Radius.circular(2)),
         Paint()..color = const Color(0xFF050B14));
 
     canvas.drawRRect(
@@ -343,7 +346,8 @@ class LaneWorld extends Component {
 
     final tp = _cachedBillboards[text];
     if (tp != null) {
-      tp.paint(canvas, Offset(x + (w - tp.width) / 2, bbY + (12 - tp.height) / 2));
+      tp.paint(
+          canvas, Offset(x + (w - tp.width) / 2, bbY + (12 - tp.height) / 2));
     }
   }
 
@@ -351,12 +355,12 @@ class LaneWorld extends Component {
     canvas.drawLine(Offset(x, baseY), Offset(x, baseY - 24), _antPaint);
     final beaconFlash = sin(_searchlightAngle * 4 + seed) > 0.0;
     if (beaconFlash) {
-      canvas.drawCircle(Offset(x, baseY - 24), 4.5,
-          Paint()..color = const Color(0x66FF2A4B));
-      canvas.drawCircle(Offset(x, baseY - 24), 2.0,
-          Paint()..color = const Color(0xFFFF2A4B));
-      canvas.drawCircle(Offset(x, baseY - 24), 1.0,
-          Paint()..color = const Color(0xFFFFFFFF));
+      canvas.drawCircle(
+          Offset(x, baseY - 24), 4.5, Paint()..color = const Color(0x66FF2A4B));
+      canvas.drawCircle(
+          Offset(x, baseY - 24), 2.0, Paint()..color = const Color(0xFFFF2A4B));
+      canvas.drawCircle(
+          Offset(x, baseY - 24), 1.0, Paint()..color = const Color(0xFFFFFFFF));
     }
   }
 
@@ -370,7 +374,8 @@ class LaneWorld extends Component {
         colors: [Color(0xFF09061A), Color(0xFF04020C)],
       ).createShader(rect);
     canvas.drawRect(rect, paint);
-    canvas.drawLine(Offset(x, baseY - h), Offset(x, baseY - h - 35), _spirePaint);
+    canvas.drawLine(
+        Offset(x, baseY - h), Offset(x, baseY - h - 35), _spirePaint);
     canvas.drawCircle(Offset(x, baseY - h - 35), 2.5,
         Paint()..color = const Color(0xFFFF2A4B));
   }
@@ -471,7 +476,8 @@ class LaneWorld extends Component {
       canvas.drawPath(path, _tilePaint);
 
       _seamPaint
-        ..color = _curAccentColor.withValues(alpha: (tNear * 0.35).clamp(0.0, 0.4))
+        ..color =
+            _curAccentColor.withValues(alpha: (tNear * 0.35).clamp(0.0, 0.4))
         ..strokeWidth = (1.0 + tNear * 1.5);
       canvas.drawLine(pNearL, pNearR, _seamPaint);
 
@@ -487,7 +493,8 @@ class LaneWorld extends Component {
           ..lineTo(chevronCenter.dx + chW, chevronCenter.dy + chH);
 
         _chevronPaint
-          ..color = _curAccentColor.withValues(alpha: (tNear * 0.45).clamp(0.0, 0.45))
+          ..color =
+              _curAccentColor.withValues(alpha: (tNear * 0.45).clamp(0.0, 0.45))
           ..strokeWidth = (1.2 + tNear * 2.0);
 
         canvas.drawPath(chevronPath, _chevronPaint);
@@ -665,8 +672,8 @@ class LaneWorld extends Component {
     final boardW = (pRightTop.dx - pLeftTop.dx) * 0.82;
     final boardH = 24.0 * t;
 
-    final boardRect =
-        Rect.fromCenter(center: Offset(midX, boardY), width: boardW, height: boardH);
+    final boardRect = Rect.fromCenter(
+        center: Offset(midX, boardY), width: boardW, height: boardH);
 
     _boardBgPaint.shader = LinearGradient(
       begin: Alignment.topCenter,
@@ -676,14 +683,14 @@ class LaneWorld extends Component {
         const Color(0xFF020617).withValues(alpha: alpha * 0.95),
       ],
     ).createShader(boardRect);
-    canvas.drawRRect(
-        RRect.fromRectAndRadius(boardRect, Radius.circular(4 * t)), _boardBgPaint);
+    canvas.drawRRect(RRect.fromRectAndRadius(boardRect, Radius.circular(4 * t)),
+        _boardBgPaint);
 
     _boardBorderPaint
       ..color = _curAccentColor.withValues(alpha: alpha * 0.9)
       ..strokeWidth = 1.6 * t;
-    canvas.drawRRect(
-        RRect.fromRectAndRadius(boardRect, Radius.circular(4 * t)), _boardBorderPaint);
+    canvas.drawRRect(RRect.fromRectAndRadius(boardRect, Radius.circular(4 * t)),
+        _boardBorderPaint);
 
     // Brackets
     final bracketLen = 6.0 * t;

--- a/shorebird_runner/lib/game/components/obstacle.dart
+++ b/shorebird_runner/lib/game/components/obstacle.dart
@@ -492,7 +492,8 @@ class Obstacle extends Component {
       width: barW,
       height: barH * 0.55,
     );
-    final railRRect = RRect.fromRectAndRadius(railRect, Radius.circular(4 * scale));
+    final railRRect =
+        RRect.fromRectAndRadius(railRect, Radius.circular(4 * scale));
 
     canvas.drawRRect(railRRect, Paint()..color = const Color(0xFFFFB300));
 
@@ -527,8 +528,7 @@ class Obstacle extends Component {
           beaconPos,
           10 * scale,
           Paint()
-            ..color =
-                const Color(0xFFFFD54F).withValues(alpha: 0.25 * scale),
+            ..color = const Color(0xFFFFD54F).withValues(alpha: 0.25 * scale),
         );
       }
 
@@ -565,7 +565,8 @@ class Obstacle extends Component {
       ..strokeWidth = 6.0 * scale
       ..strokeCap = StrokeCap.round
       ..style = PaintingStyle.stroke;
-    canvas.drawLine(Offset(leftPostX, groundY), Offset(leftPostX, topY), postPaint);
+    canvas.drawLine(
+        Offset(leftPostX, groundY), Offset(leftPostX, topY), postPaint);
     canvas.drawLine(
         Offset(rightPostX, groundY), Offset(rightPostX, topY), postPaint);
 
@@ -597,8 +598,7 @@ class Obstacle extends Component {
 
     // "UNDER REVIEW" pre-cached text banner
     canvas.save();
-    canvas.translate(
-        pos.dx - (_reviewGatePainter.width * scale * 0.9) / 2,
+    canvas.translate(pos.dx - (_reviewGatePainter.width * scale * 0.9) / 2,
         topY + 8 * scale - (_reviewGatePainter.height * scale * 0.9) / 2);
     canvas.scale(scale * 0.9, scale * 0.9);
     _reviewGatePainter.paint(canvas, Offset.zero);
@@ -616,8 +616,8 @@ class Obstacle extends Component {
         Offset(leftPostX, ly),
         Offset(rightPostX, ly),
         Paint()
-          ..color =
-              const Color(0xFFFF1744).withValues(alpha: 0.25 * laserPulse * scale)
+          ..color = const Color(0xFFFF1744)
+              .withValues(alpha: 0.25 * laserPulse * scale)
           ..strokeWidth = 8.0 * scale
           ..strokeCap = StrokeCap.round
           ..style = PaintingStyle.stroke,
@@ -627,8 +627,7 @@ class Obstacle extends Component {
         Offset(leftPostX, ly),
         Offset(rightPostX, ly),
         Paint()
-          ..color =
-              const Color(0xFFFF5252).withValues(alpha: 0.95 * scale)
+          ..color = const Color(0xFFFF5252).withValues(alpha: 0.95 * scale)
           ..strokeWidth = 3.0 * scale
           ..strokeCap = StrokeCap.round
           ..style = PaintingStyle.stroke,

--- a/shorebird_runner/lib/game/components/patch.dart
+++ b/shorebird_runner/lib/game/components/patch.dart
@@ -187,10 +187,16 @@ class Patch extends Component {
 
     // Radiant Golden/Cyan Magnetic Attraction Field
     if (isBeingMagnetized) {
-      canvas.drawCircle(Offset.zero, size * 1.05,
-          Paint()..color = const Color(0xFFFFD700).withValues(alpha: 0.20 * scale));
-      canvas.drawCircle(Offset.zero, size * 0.75,
-          Paint()..color = const Color(0xFFFFD700).withValues(alpha: 0.45 * scale));
+      canvas.drawCircle(
+          Offset.zero,
+          size * 1.05,
+          Paint()
+            ..color = const Color(0xFFFFD700).withValues(alpha: 0.20 * scale));
+      canvas.drawCircle(
+          Offset.zero,
+          size * 0.75,
+          Paint()
+            ..color = const Color(0xFFFFD700).withValues(alpha: 0.45 * scale));
 
       final fluxPaint = Paint()
         ..color = const Color(0xFF00FFCC).withValues(alpha: 0.85 * scale)
@@ -209,14 +215,23 @@ class Patch extends Component {
           const Color(0xFF00E5FF).withValues(alpha: 0.30 * scale),
           const Color(0xFF00E5FF).withValues(alpha: 0.0),
         ],
-      ).createShader(Rect.fromLTWH(-8 * scale, -90 * scale, 16 * scale, 90 * scale));
-    canvas.drawRect(Rect.fromLTWH(-8 * scale, -90 * scale, 16 * scale, 90 * scale), beamPaint);
+      ).createShader(
+          Rect.fromLTWH(-8 * scale, -90 * scale, 16 * scale, 90 * scale));
+    canvas.drawRect(
+        Rect.fromLTWH(-8 * scale, -90 * scale, 16 * scale, 90 * scale),
+        beamPaint);
 
     // 1. Radiant Cyan/Gold Ambient Glow (concentric circles, zero blur overhead)
-    canvas.drawCircle(Offset.zero, size * 0.85,
-        Paint()..color = const Color(0xFF00D4FF).withValues(alpha: 0.16 * scale));
-    canvas.drawCircle(Offset.zero, size * 0.58,
-        Paint()..color = const Color(0xFF00D4FF).withValues(alpha: 0.38 * scale));
+    canvas.drawCircle(
+        Offset.zero,
+        size * 0.85,
+        Paint()
+          ..color = const Color(0xFF00D4FF).withValues(alpha: 0.16 * scale));
+    canvas.drawCircle(
+        Offset.zero,
+        size * 0.58,
+        Paint()
+          ..color = const Color(0xFF00D4FF).withValues(alpha: 0.38 * scale));
 
     // Concentric Holographic Gyroscope Orbiting Rings
     final ring1Paint = Paint()
@@ -225,7 +240,9 @@ class Patch extends Component {
       ..style = PaintingStyle.stroke;
     canvas.drawOval(
         Rect.fromCenter(
-            center: Offset.zero, width: size * 1.2 * absCos, height: size * 1.2),
+            center: Offset.zero,
+            width: size * 1.2 * absCos,
+            height: size * 1.2),
         ring1Paint);
 
     // 2. Futuristic Hexagonal OTA Patch Badge
@@ -283,10 +300,16 @@ class Patch extends Component {
     final absCos = cosSpin.abs().clamp(0.2, 1.0);
 
     // Radiant Gold / Crimson Energy Aura (concentric glow)
-    canvas.drawCircle(Offset.zero, size * 0.95,
-        Paint()..color = const Color(0xFFFFD700).withValues(alpha: 0.22 * scale));
-    canvas.drawCircle(Offset.zero, size * 0.65,
-        Paint()..color = const Color(0xFFFFD700).withValues(alpha: 0.50 * scale));
+    canvas.drawCircle(
+        Offset.zero,
+        size * 0.95,
+        Paint()
+          ..color = const Color(0xFFFFD700).withValues(alpha: 0.22 * scale));
+    canvas.drawCircle(
+        Offset.zero,
+        size * 0.65,
+        Paint()
+          ..color = const Color(0xFFFFD700).withValues(alpha: 0.50 * scale));
 
     // Outer rotating energy ring
     final ringPaint = Paint()
@@ -295,7 +318,9 @@ class Patch extends Component {
       ..style = PaintingStyle.stroke;
     canvas.drawOval(
         Rect.fromCenter(
-            center: Offset.zero, width: size * 1.3 * absCos, height: size * 1.3),
+            center: Offset.zero,
+            width: size * 1.3 * absCos,
+            height: size * 1.3),
         ringPaint);
 
     // Octagonal Core

--- a/shorebird_runner/lib/game/components/player.dart
+++ b/shorebird_runner/lib/game/components/player.dart
@@ -142,6 +142,16 @@ class Player extends Component {
     }
   }
 
+  void moveToLane(int desiredLane) {
+    final target = desiredLane.clamp(0, GameConfig.laneCount - 1);
+    if (target == _targetLane) return;
+    currentLane = _targetLane;
+    _targetLane = target;
+    _laneProgress = 0.0;
+    _moveDirection = target > currentLane ? 1 : -1;
+    AudioService.playSwitch();
+  }
+
   void jump() {
     if (!_isJumping && !_isSliding) {
       _isJumping = true;
@@ -265,7 +275,8 @@ class Player extends Component {
       if (stride.abs() > 0.85 && _particles.length < 24) {
         final footX = pos.dx + (stride > 0 ? 12.0 : -12.0);
         final sparkColor = _getAuraColor();
-        _particles.add(_DashSpark(Offset(footX, pos.dy + 32), _rng, sparkColor));
+        _particles
+            .add(_DashSpark(Offset(footX, pos.dy + 32), _rng, sparkColor));
       }
     }
 
@@ -324,7 +335,8 @@ class Player extends Component {
         width: 52 * shadowScale,
         height: 18 * shadowScale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.25),
+      Paint()
+        ..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.25),
     );
     canvas.drawOval(
       Rect.fromCenter(
@@ -332,7 +344,8 @@ class Player extends Component {
         width: 38 * shadowScale,
         height: 13 * shadowScale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.55),
+      Paint()
+        ..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.55),
     );
     canvas.drawOval(
       Rect.fromCenter(
@@ -340,7 +353,8 @@ class Player extends Component {
         width: 22 * shadowScale,
         height: 7 * shadowScale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.85),
+      Paint()
+        ..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.85),
     );
   }
 
@@ -397,7 +411,8 @@ class Player extends Component {
             Color(0xFFFFD700),
           ],
           transform: GradientRotation(_runPhase * 4),
-        ).createShader(Rect.fromCircle(center: Offset.zero, radius: shieldRadius))
+        ).createShader(
+            Rect.fromCircle(center: Offset.zero, radius: shieldRadius))
         ..style = PaintingStyle.stroke
         ..strokeWidth = 3.5;
       canvas.drawCircle(const Offset(0, 2), shieldRadius, shieldPaint);
@@ -420,10 +435,10 @@ class Player extends Component {
         final ny = sin(nodeAngle) * (shieldRadius * 0.75) + 2;
         canvas.drawCircle(Offset(nx, ny), 5.5,
             Paint()..color = const Color(0xFF00FFCC).withValues(alpha: 0.35));
-        canvas.drawCircle(Offset(nx, ny), 3.0,
-            Paint()..color = const Color(0xFF00FFCC));
-        canvas.drawCircle(Offset(nx, ny), 1.5,
-            Paint()..color = const Color(0xFFFFFFFF));
+        canvas.drawCircle(
+            Offset(nx, ny), 3.0, Paint()..color = const Color(0xFF00FFCC));
+        canvas.drawCircle(
+            Offset(nx, ny), 1.5, Paint()..color = const Color(0xFFFFFFFF));
       }
     }
 
@@ -506,7 +521,8 @@ class Player extends Component {
 
     final shoePaint = Paint()..color = const Color(0xFF0F172A);
     final shoeRect = RRect.fromRectAndRadius(
-      Rect.fromCenter(center: const Offset(0, 0), width: 14 * scale, height: 6 * scale),
+      Rect.fromCenter(
+          center: const Offset(0, 0), width: 14 * scale, height: 6 * scale),
       Radius.circular(2 * scale),
     );
     canvas.drawRRect(shoeRect, shoePaint);
@@ -590,10 +606,10 @@ class Player extends Component {
     canvas.drawCircle(emblemCenter, r * 0.24, borderPaint);
 
     // Multi-ring concentric glow behind emblem
-    canvas.drawCircle(emblemCenter, r * 0.32,
-        Paint()..color = aura.withValues(alpha: 0.18));
-    canvas.drawCircle(emblemCenter, r * 0.26,
-        Paint()..color = aura.withValues(alpha: 0.38));
+    canvas.drawCircle(
+        emblemCenter, r * 0.32, Paint()..color = aura.withValues(alpha: 0.18));
+    canvas.drawCircle(
+        emblemCenter, r * 0.26, Paint()..color = aura.withValues(alpha: 0.38));
 
     if (skin == PlayerSkin.blueBird) {
       final birdPath = Path()
@@ -725,7 +741,8 @@ class Player extends Component {
       ..strokeWidth = 1.8;
     canvas.drawRRect(leftCupRect, cupGlow);
 
-    _drawCupEqualizer(canvas, Offset(-headRadius - 2.5, headCenter.dy + 1), aura);
+    _drawCupEqualizer(
+        canvas, Offset(-headRadius - 2.5, headCenter.dy + 1), aura);
 
     final rightCupRect = RRect.fromRectAndRadius(
       Rect.fromCenter(
@@ -760,8 +777,7 @@ class Player extends Component {
       ..color = colors.first
       ..style = PaintingStyle.fill;
 
-    final skinPaint = Paint()
-      ..color = const Color(0xFFFBBF24);
+    final skinPaint = Paint()..color = const Color(0xFFFBBF24);
 
     final leftArmSwing = -stride * r * 0.22;
     final leftShoulder = Offset(-r * 0.50, -r * 0.28);

--- a/shorebird_runner/lib/game/components/starfield.dart
+++ b/shorebird_runner/lib/game/components/starfield.dart
@@ -115,8 +115,8 @@ class Starfield extends Component {
     ).createShader(Rect.fromCircle(
         center: Offset(GameConfig.designWidth - 200 + sin2, h * 0.4),
         radius: 200));
-    canvas.drawCircle(
-        Offset(GameConfig.designWidth - 200 + sin2, h * 0.4), 200, _purpleNebulaPaint);
+    canvas.drawCircle(Offset(GameConfig.designWidth - 200 + sin2, h * 0.4), 200,
+        _purpleNebulaPaint);
   }
 }
 
@@ -158,8 +158,12 @@ class _Star {
       x: rng.nextDouble() * GameConfig.designWidth,
       y: rng.nextDouble() * (GameConfig.horizonY - 10),
       speed: 8 + rng.nextDouble() * 24,
-      size: isSpecial ? 1.8 + rng.nextDouble() * 1.4 : 0.6 + rng.nextDouble() * 1.1,
-      alpha: isSpecial ? 0.8 + rng.nextDouble() * 0.2 : 0.25 + rng.nextDouble() * 0.6,
+      size: isSpecial
+          ? 1.8 + rng.nextDouble() * 1.4
+          : 0.6 + rng.nextDouble() * 1.1,
+      alpha: isSpecial
+          ? 0.8 + rng.nextDouble() * 0.2
+          : 0.25 + rng.nextDouble() * 0.6,
       twinkleSpeed: 1.2 + rng.nextDouble() * 3.5,
       twinklePhase: rng.nextDouble() * pi * 2,
       hasCrossGlint: isSpecial,
@@ -181,8 +185,10 @@ class _Star {
     if (hasCrossGlint && currentAlpha > 0.65) {
       final spikeLen = size * 2.8 * currentAlpha;
       _sharedSpikePaint.color = tint.withValues(alpha: currentAlpha * 0.5);
-      canvas.drawLine(Offset(x - spikeLen, y), Offset(x + spikeLen, y), _sharedSpikePaint);
-      canvas.drawLine(Offset(x, y - spikeLen), Offset(x, y + spikeLen), _sharedSpikePaint);
+      canvas.drawLine(
+          Offset(x - spikeLen, y), Offset(x + spikeLen, y), _sharedSpikePaint);
+      canvas.drawLine(
+          Offset(x, y - spikeLen), Offset(x, y + spikeLen), _sharedSpikePaint);
     }
   }
 }
@@ -215,7 +221,8 @@ class _ShootingStar {
   bool get isDead => life <= 0;
 
   void update(double dt) {
-    current = Offset(current.dx + velocity.dx * dt, current.dy + velocity.dy * dt);
+    current =
+        Offset(current.dx + velocity.dx * dt, current.dy + velocity.dy * dt);
     life = (life - dt * 1.8).clamp(0.0, 1.0);
   }
 

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -81,11 +81,15 @@ class ShorebirdRunnerGame extends FlameGame
 
   @override
   Future<void> onLoad() async {
+    camera.viewfinder.position = Vector2(
+      GameConfig.designWidth / 2,
+      GameConfig.designHeight / 2,
+    );
+    camera.viewfinder.anchor = Anchor.center;
     camera.viewfinder.visibleGameSize = Vector2(
       GameConfig.designWidth,
       GameConfig.designHeight,
     );
-    camera.viewfinder.anchor = Anchor.topLeft;
 
     highScore = await HighScoreService.load();
 
@@ -308,7 +312,8 @@ class ShorebirdRunnerGame extends FlameGame
         score += 150;
         _hud.score = score;
         AudioService.playStomp();
-        _addFloatingText('🦘 LEAP! +150', o.worldPosition, const Color(0xFF00E5FF),
+        _addFloatingText(
+            '🦘 LEAP! +150', o.worldPosition, const Color(0xFF00E5FF),
             size: 17);
       }
       return false;
@@ -321,7 +326,8 @@ class ShorebirdRunnerGame extends FlameGame
         score += 150;
         _hud.score = score;
         AudioService.playSlide();
-        _addFloatingText('⚡ SLIDE! +150', o.worldPosition, const Color(0xFFFFD700),
+        _addFloatingText(
+            '⚡ SLIDE! +150', o.worldPosition, const Color(0xFFFFD700),
             size: 17);
       }
       return false;
@@ -343,8 +349,8 @@ class ShorebirdRunnerGame extends FlameGame
     AudioService.playStomp();
     _screenShake = 0.8;
 
-    _addFloatingText('💥 SQUASHED! +300', o.worldPosition,
-        const Color(0xFF00FF88),
+    _addFloatingText(
+        '💥 SQUASHED! +300', o.worldPosition, const Color(0xFF00FF88),
         size: 18);
   }
 
@@ -366,7 +372,8 @@ class ShorebirdRunnerGame extends FlameGame
     score += GameConfig.patchPoints;
 
     if (p.isHotReloadBooster) {
-      _player.triggerHotReload(6.0); // 6 seconds of invincible Hot Reload power!
+      _player
+          .triggerHotReload(6.0); // 6 seconds of invincible Hot Reload power!
       _hud.triggerComboFlash();
       _screenShake = 0.5;
       _addFloatingText('🔥 HOT RELOAD! +500', pos, const Color(0xFFFF9100),
@@ -548,29 +555,27 @@ class ShorebirdRunnerGame extends FlameGame
     }
   }
 
-  // ── Tap Zones (Mobile Accessibility) ─────────────────────────────────────
+  void moveToLane(int lane) => _player.moveToLane(lane);
+  void moveLeft() => _player.moveLeft();
+  void moveRight() => _player.moveRight();
+  void jump() => _player.jump();
+  void slide() => _player.slide();
+  int get currentLane => _player.currentLane;
+
+  // ── Tap on Lane (Direct Lane Steering) ──────────────────────────────────
 
   @override
   void onTapDown(TapDownEvent event) {
     if (_isOver) return;
     final tapX = event.canvasPosition.x;
-    final tapY = event.canvasPosition.y;
 
-    // Top 28% triggers Jump
-    if (tapY < size.y * 0.28) {
-      _player.jump();
-      return;
-    }
-    // Bottom 25% triggers Slide
-    if (tapY > size.y * 0.75) {
-      _player.slide();
-      return;
-    }
-    // Left/Right half lane steers
-    if (tapX < size.x / 2) {
-      _player.moveLeft();
+    // Directly click on the desired lane to move player there
+    if (tapX < size.x * 0.36) {
+      _player.moveToLane(0);
+    } else if (tapX > size.x * 0.64) {
+      _player.moveToLane(2);
     } else {
-      _player.moveRight();
+      _player.moveToLane(1);
     }
   }
 }

--- a/shorebird_runner/lib/game/utils/audio_service.dart
+++ b/shorebird_runner/lib/game/utils/audio_service.dart
@@ -1,9 +1,5 @@
-// ignore_for_file: avoid_web_libraries_in_flutter
-import 'package:flutter/foundation.dart';
-import 'dart:js_interop';
-
-@JS('playArcadeSound')
-external void _playArcadeSound(JSString type);
+import 'audio_service_stub.dart'
+    if (dart.library.js_interop) 'audio_service_web.dart';
 
 /// Cross-platform arcade sound service.
 /// Uses Web Audio synthesis on web and fails silently on other platforms.
@@ -23,11 +19,6 @@ class AudioService {
   static void playCrash() => _play('crash');
 
   static void _play(String soundType) {
-    if (!kIsWeb) return;
-    try {
-      _playArcadeSound(soundType.toJS);
-    } catch (_) {
-      // Graceful fallback if Web Audio is blocked or not available
-    }
+    playArcadeSoundImpl(soundType);
   }
 }

--- a/shorebird_runner/lib/game/utils/audio_service_stub.dart
+++ b/shorebird_runner/lib/game/utils/audio_service_stub.dart
@@ -1,0 +1,3 @@
+void playArcadeSoundImpl(String soundType) {
+  // No-op on VM/mobile/desktop tests
+}

--- a/shorebird_runner/lib/game/utils/audio_service_web.dart
+++ b/shorebird_runner/lib/game/utils/audio_service_web.dart
@@ -1,0 +1,12 @@
+import 'dart:js_interop';
+
+@JS('playArcadeSound')
+external void _playArcadeSound(JSString type);
+
+void playArcadeSoundImpl(String soundType) {
+  try {
+    _playArcadeSound(soundType.toJS);
+  } catch (_) {
+    // Graceful fallback if Web Audio is blocked or not available
+  }
+}

--- a/shorebird_runner/lib/game/utils/game_config.dart
+++ b/shorebird_runner/lib/game/utils/game_config.dart
@@ -238,12 +238,12 @@ class GameConfig {
   static const int timePoints = 2;
 
   // ── Shorebird Brand Colors ────────────────────────────────────────────────
-  static const int colorBg = 0xFF0C0D10;        // Deep black-navy
-  static const int colorGold = 0xFFFFC107;       // Shorebird primary gold
-  static const int colorAmber = 0xFFFF8F00;      // Shorebird amber
-  static const int colorCyan = 0xFF00BCD4;       // Pro tier electric cyan
-  static const int colorGreen = 0xFF4CAF50;      // Business tier green
-  static const int colorPurple = 0xFF9C27B0;     // Enterprise violet
-  static const int colorCoral = 0xFFFF5252;      // Error/danger red
+  static const int colorBg = 0xFF0C0D10; // Deep black-navy
+  static const int colorGold = 0xFFFFC107; // Shorebird primary gold
+  static const int colorAmber = 0xFFFF8F00; // Shorebird amber
+  static const int colorCyan = 0xFF00BCD4; // Pro tier electric cyan
+  static const int colorGreen = 0xFF4CAF50; // Business tier green
+  static const int colorPurple = 0xFF9C27B0; // Enterprise violet
+  static const int colorCoral = 0xFFFF5252; // Error/danger red
   static const int colorGrid = 0xFF111520;
 }

--- a/shorebird_runner/lib/main.dart
+++ b/shorebird_runner/lib/main.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'package:flame/game.dart';
 import 'package:flutter/material.dart';
 import 'package:shorebird_runner/game/shorebird_runner_game.dart';
+import 'package:shorebird_runner/game/utils/audio_service.dart';
 import 'package:shorebird_runner/game/utils/game_config.dart';
 import 'package:shorebird_runner/screens/lobby_screen.dart';
 import 'package:shorebird_runner/screens/multiplayer_race_screen.dart';
@@ -25,7 +27,7 @@ class PatchRushApp extends StatelessWidget {
         brightness: Brightness.dark,
         scaffoldBackgroundColor: const Color(0xFF0C0D10),
         colorScheme: const ColorScheme.dark(
-          primary: Color(0xFFFFC107),   // Shorebird Gold
+          primary: Color(0xFFFFC107), // Shorebird Gold
           secondary: Color(0xFF00BCD4), // Pro Cyan
           surface: Color(0xFF111520),
           onPrimary: Color(0xFF1A1200),
@@ -53,6 +55,7 @@ class _GameShellState extends State<GameShell> {
   AppMode _mode = AppMode.menu;
   ShorebirdRunnerGame? _soloGame;
   List<RacerStanding> _lastPodiumRankings = [];
+  StreamSubscription<void>? _rematchSub;
 
   @override
   void initState() {
@@ -61,6 +64,19 @@ class _GameShellState extends State<GameShell> {
     if (Uri.base.queryParameters.containsKey('room')) {
       _mode = AppMode.lobby;
     }
+
+    _rematchSub = LobbyService.instance.onRematchTriggered.listen((_) {
+      if (!mounted) return;
+      if (_mode == AppMode.podium || _mode == AppMode.race) {
+        setState(() => _mode = AppMode.lobby);
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _rematchSub?.cancel();
+    super.dispose();
   }
 
   void _startSolo() {
@@ -79,6 +95,112 @@ class _GameShellState extends State<GameShell> {
       _soloGame = null;
     });
     Future.microtask(() => _startSolo());
+  }
+
+  Widget _buildMobileControlBar({
+    required VoidCallback onLeft,
+    required VoidCallback onMid,
+    required VoidCallback onRight,
+    required VoidCallback onJump,
+    required VoidCallback onSlide,
+  }) {
+    return Container(
+      color: const Color(0xFF070B12),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: _buildTouchButton(
+                label: 'LEFT',
+                icon: Icons.arrow_left,
+                color: const Color(0xFF00D4FF),
+                onTap: onLeft,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'MID',
+                icon: Icons.adjust,
+                color: const Color(0xFFFFC107),
+                onTap: onMid,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'RIGHT',
+                icon: Icons.arrow_right,
+                color: const Color(0xFF00D4FF),
+                onTap: onRight,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'JUMP',
+                icon: Icons.keyboard_double_arrow_up,
+                color: const Color(0xFF00FF88),
+                onTap: onJump,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'SLIDE',
+                icon: Icons.keyboard_double_arrow_down,
+                color: const Color(0xFFFF9100),
+                onTap: onSlide,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTouchButton({
+    required String label,
+    required IconData icon,
+    required Color color,
+    required VoidCallback onTap,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () {
+          AudioService.playSelect();
+          onTap();
+        },
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 10),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.14),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: color.withValues(alpha: 0.45)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: color, size: 18),
+              const SizedBox(height: 2),
+              Text(
+                label,
+                style: TextStyle(
+                  color: color,
+                  fontWeight: FontWeight.w900,
+                  fontSize: 10,
+                  letterSpacing: 1.0,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 
   @override
@@ -112,10 +234,10 @@ class _GameShellState extends State<GameShell> {
 
       case AppMode.podium:
         return TournamentPodiumScreen(
+          isHost: LobbyService.instance.isHost,
           rankings: _lastPodiumRankings,
           onRematch: () {
-            LobbyService.instance.resetMatch();
-            setState(() => _mode = AppMode.lobby);
+            LobbyService.instance.requestRematch();
           },
           onReturnToLobby: () {
             LobbyService.instance.leaveRoom();
@@ -126,49 +248,144 @@ class _GameShellState extends State<GameShell> {
       case AppMode.solo:
         return Scaffold(
           backgroundColor: const Color(0xFF0C0D10),
-          body: Center(
-            child: AspectRatio(
-              aspectRatio: 800 / 600,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: const Color(0xFFFFC107).withValues(alpha: 0.20),
-                      width: 1.5,
-                    ),
-                    boxShadow: [
-                      BoxShadow(
-                        color: const Color(0xFFFFC107).withValues(alpha: 0.08),
-                        blurRadius: 48,
-                        spreadRadius: 4,
+          body: SafeArea(
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                final isMobile =
+                    constraints.maxWidth < 800 || constraints.maxHeight < 600;
+                final isPortrait = constraints.maxHeight > constraints.maxWidth;
+
+                Widget gameContent = Stack(
+                  children: [
+                    Positioned.fill(
+                      child: GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        onTapDown: (details) {
+                          if (_soloGame == null || _soloGame!.isOver) return;
+                          final RenderBox? box =
+                              context.findRenderObject() as RenderBox?;
+                          final width = box?.size.width ?? constraints.maxWidth;
+                          final x = details.localPosition.dx;
+                          if (x < width * 0.36) {
+                            _soloGame!.moveToLane(0);
+                          } else if (x > width * 0.64) {
+                            _soloGame!.moveToLane(2);
+                          } else {
+                            _soloGame!.moveToLane(1);
+                          }
+                        },
+                        child: GameWidget(
+                          game: _soloGame!,
+                          overlayBuilderMap: {
+                            'game_over': (context, game) {
+                              final g = game as ShorebirdRunnerGame;
+                              return _GameOverOverlay(
+                                score: g.score,
+                                highScore: g.highScore,
+                                totalPatches: g.totalPatches,
+                                level: g.currentLevel,
+                                onRestart: _restartSolo,
+                                onMenu: () => setState(() {
+                                  _soloGame = null;
+                                  _mode = AppMode.menu;
+                                }),
+                              );
+                            },
+                          },
+                          backgroundBuilder: (context) => Container(
+                            color: const Color(0xFF0C0D10),
+                          ),
+                        ),
                       ),
+                    ),
+                    Positioned(
+                      top: 10,
+                      left: 10,
+                      child: Material(
+                        color: Colors.transparent,
+                        child: InkWell(
+                          onTap: () {
+                            AudioService.playSelect();
+                            setState(() {
+                              _soloGame = null;
+                              _mode = AppMode.menu;
+                            });
+                          },
+                          borderRadius: BorderRadius.circular(8),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 10, vertical: 6),
+                            decoration: BoxDecoration(
+                              color: Colors.black.withValues(alpha: 0.65),
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(color: Colors.white24),
+                            ),
+                            child: const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(Icons.arrow_back,
+                                    color: Colors.white70, size: 14),
+                                SizedBox(width: 4),
+                                Text(
+                                  'MENU',
+                                  style: TextStyle(
+                                    color: Colors.white70,
+                                    fontSize: 11,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                );
+
+                if (isMobile) {
+                  return Column(
+                    children: [
+                      Expanded(child: gameContent),
+                      if (isPortrait)
+                        _buildMobileControlBar(
+                          onLeft: () => _soloGame?.moveLeft(),
+                          onMid: () => _soloGame?.moveToLane(1),
+                          onRight: () => _soloGame?.moveRight(),
+                          onJump: () => _soloGame?.jump(),
+                          onSlide: () => _soloGame?.slide(),
+                        ),
                     ],
-                  ),
-                  child: GameWidget(
-                    game: _soloGame!,
-                    overlayBuilderMap: {
-                      'game_over': (context, game) {
-                        final g = game as ShorebirdRunnerGame;
-                        return _GameOverOverlay(
-                          score: g.score,
-                          highScore: g.highScore,
-                          totalPatches: g.totalPatches,
-                          level: g.currentLevel,
-                          onRestart: _restartSolo,
-                          onMenu: () => setState(() {
-                            _soloGame = null;
-                            _mode = AppMode.menu;
-                          }),
-                        );
-                      },
-                    },
-                    backgroundBuilder: (context) => Container(
-                      color: const Color(0xFF0C0D10),
+                  );
+                }
+
+                return Center(
+                  child: AspectRatio(
+                    aspectRatio: 800 / 600,
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(8),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color:
+                                const Color(0xFFFFC107).withValues(alpha: 0.20),
+                            width: 1.5,
+                          ),
+                          boxShadow: [
+                            BoxShadow(
+                              color: const Color(0xFFFFC107)
+                                  .withValues(alpha: 0.08),
+                              blurRadius: 48,
+                              spreadRadius: 4,
+                            ),
+                          ],
+                        ),
+                        child: gameContent,
+                      ),
                     ),
                   ),
-                ),
-              ),
+                );
+              },
             ),
           ),
         );

--- a/shorebird_runner/lib/screens/multiplayer_race_screen.dart
+++ b/shorebird_runner/lib/screens/multiplayer_race_screen.dart
@@ -90,260 +90,406 @@ class _MultiplayerRaceScreenState extends State<MultiplayerRaceScreen> {
 
     return Scaffold(
       backgroundColor: const Color(0xFF050A14),
-      body: Stack(
-        children: [
-          // 3D Game Canvas
-          Center(
-            child: AspectRatio(
-              aspectRatio: 800 / 600,
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Container(
-                  decoration: BoxDecoration(
-                    border: Border.all(
-                      color: const Color(0xFF00D4FF).withValues(alpha: 0.3),
-                      width: 1.5,
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isMobile =
+              constraints.maxWidth < 800 || constraints.maxHeight < 600;
+          final isPortrait = constraints.maxHeight > constraints.maxWidth;
+
+          Widget gameCanvas = GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onTapDown: (details) {
+              if (_game == null || _game!.isOver) return;
+              final width = constraints.maxWidth;
+              final x = details.localPosition.dx;
+              if (x < width * 0.36) {
+                _game!.moveToLane(0);
+              } else if (x > width * 0.64) {
+                _game!.moveToLane(2);
+              } else {
+                _game!.moveToLane(1);
+              }
+            },
+            child: GameWidget(
+              game: _game!,
+              backgroundBuilder: (context) => Container(
+                color: const Color(0xFF0A0E1A),
+              ),
+            ),
+          );
+
+          Widget renderedCanvas;
+          if (isMobile) {
+            renderedCanvas = Positioned.fill(child: gameCanvas);
+          } else {
+            renderedCanvas = Center(
+              child: AspectRatio(
+                aspectRatio: 800 / 600,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(
+                        color: const Color(0xFF00D4FF).withValues(alpha: 0.3),
+                        width: 1.5,
+                      ),
                     ),
-                  ),
-                  child: GameWidget(
-                    game: _game!,
-                    backgroundBuilder: (context) => Container(
-                      color: const Color(0xFF0A0E1A),
-                    ),
+                    child: gameCanvas,
                   ),
                 ),
               ),
-            ),
-          ),
+            );
+          }
 
-          // Top Header Overlay: Room Code & Status
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Room Badge & Leave Button
-                  Row(
+          return Stack(
+            children: [
+              // 3D Game Canvas
+              renderedCanvas,
+
+              // Top Header Overlay: Room Code & Status
+              SafeArea(
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 6),
-                        decoration: BoxDecoration(
-                          color:
-                              const Color(0xFF0A192F).withValues(alpha: 0.85),
-                          borderRadius: BorderRadius.circular(8),
-                          border: Border.all(
-                              color: const Color(0xFF00D4FF)
-                                  .withValues(alpha: 0.5)),
-                        ),
-                        child: Row(
-                          children: [
-                            const Text('🌐 ROOM: ',
-                                style: TextStyle(
-                                    color: Colors.white60,
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold)),
-                            Text(
-                              _lobby.currentRoomCode ?? '----',
-                              style: const TextStyle(
-                                color: Color(0xFF00D4FF),
-                                fontWeight: FontWeight.w900,
-                                fontSize: 13,
-                                letterSpacing: 2.0,
-                              ),
+                      // Room Badge & Leave Button
+                      Row(
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 6),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF0A192F)
+                                  .withValues(alpha: 0.85),
+                              borderRadius: BorderRadius.circular(8),
+                              border: Border.all(
+                                  color: const Color(0xFF00D4FF)
+                                      .withValues(alpha: 0.5)),
                             ),
-                          ],
-                        ),
+                            child: Row(
+                              children: [
+                                const Text('🌐 ROOM: ',
+                                    style: TextStyle(
+                                        color: Colors.white60,
+                                        fontSize: 11,
+                                        fontWeight: FontWeight.bold)),
+                                Text(
+                                  _lobby.currentRoomCode ?? '----',
+                                  style: const TextStyle(
+                                    color: Color(0xFF00D4FF),
+                                    fontWeight: FontWeight.w900,
+                                    fontSize: 13,
+                                    letterSpacing: 2.0,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          InkWell(
+                            onTap: () {
+                              AudioService.playSelect();
+                              widget.onLeaveRace();
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 10, vertical: 6),
+                              decoration: BoxDecoration(
+                                color: Colors.black.withValues(alpha: 0.6),
+                                borderRadius: BorderRadius.circular(8),
+                                border: Border.all(color: Colors.white24),
+                              ),
+                              child: const Text('QUIT',
+                                  style: TextStyle(
+                                      color: Colors.white70,
+                                      fontSize: 11,
+                                      fontWeight: FontWeight.bold)),
+                            ),
+                          ),
+                        ],
                       ),
-                      const SizedBox(width: 8),
-                      InkWell(
-                        onTap: () {
-                          AudioService.playSelect();
-                          widget.onLeaveRace();
-                        },
+
+                      // Real-time Standings Mini Board
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 220),
                         child: Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 6),
+                              horizontal: 12, vertical: 8),
                           decoration: BoxDecoration(
-                            color: Colors.black.withValues(alpha: 0.6),
-                            borderRadius: BorderRadius.circular(8),
-                            border: Border.all(color: Colors.white24),
+                            color:
+                                const Color(0xFF0A192F).withValues(alpha: 0.88),
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
+                                color: const Color(0xFFFFB347)
+                                    .withValues(alpha: 0.4)),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.5),
+                                blurRadius: 10,
+                              ),
+                            ],
                           ),
-                          child: const Text('QUIT',
-                              style: TextStyle(
-                                  color: Colors.white70,
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.bold)),
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              const Row(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text(
+                                    'LIVE RACE',
+                                    style: TextStyle(
+                                      color: Color(0xFFFFB347),
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.w900,
+                                      letterSpacing: 1.5,
+                                    ),
+                                  ),
+                                  Icon(Icons.bolt,
+                                      color: Color(0xFFFFB347), size: 12),
+                                ],
+                              ),
+                              const SizedBox(height: 6),
+                              ...standings.take(4).map((s) {
+                                final isMe = s.id == _lobby.myPlayerId;
+                                String medal = '#${s.rank}';
+                                if (s.rank == 1) medal = '🥇';
+                                if (s.rank == 2) medal = '🥈';
+                                if (s.rank == 3) medal = '🥉';
+
+                                return Padding(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 2),
+                                  child: Row(
+                                    children: [
+                                      Text(medal,
+                                          style: const TextStyle(fontSize: 10)),
+                                      const SizedBox(width: 4),
+                                      Expanded(
+                                        child: Text(
+                                          s.name + (isMe ? ' (YOU)' : ''),
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: TextStyle(
+                                            color: isMe
+                                                ? const Color(0xFF00D4FF)
+                                                : Colors.white,
+                                            fontWeight: isMe
+                                                ? FontWeight.w900
+                                                : FontWeight.w600,
+                                            fontSize: 11,
+                                          ),
+                                        ),
+                                      ),
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        s.isAlive ? '${s.score}' : '💥',
+                                        style: TextStyle(
+                                          color: s.isAlive
+                                              ? const Color(0xFF00FF88)
+                                              : const Color(0xFFFF2A4B),
+                                          fontWeight: FontWeight.w900,
+                                          fontSize: 11,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                );
+                              }),
+                            ],
+                          ),
                         ),
                       ),
                     ],
                   ),
-
-                  // Real-time Standings Mini Board
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 220),
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 8),
-                      decoration: BoxDecoration(
-                        color: const Color(0xFF0A192F).withValues(alpha: 0.88),
-                        borderRadius: BorderRadius.circular(10),
-                        border: Border.all(
-                            color:
-                                const Color(0xFFFFB347).withValues(alpha: 0.4)),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withValues(alpha: 0.5),
-                            blurRadius: 10,
-                          ),
-                        ],
-                      ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          const Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                'LIVE RACE',
-                                style: TextStyle(
-                                  color: Color(0xFFFFB347),
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.w900,
-                                  letterSpacing: 1.5,
-                                ),
-                              ),
-                              Icon(Icons.bolt,
-                                  color: Color(0xFFFFB347), size: 12),
-                            ],
-                          ),
-                          const SizedBox(height: 6),
-                          ...standings.take(4).map((s) {
-                            final isMe = s.id == _lobby.myPlayerId;
-                            String medal = '#${s.rank}';
-                            if (s.rank == 1) medal = '🥇';
-                            if (s.rank == 2) medal = '🥈';
-                            if (s.rank == 3) medal = '🥉';
-
-                            return Padding(
-                              padding: const EdgeInsets.symmetric(vertical: 2),
-                              child: Row(
-                                children: [
-                                  Text(medal,
-                                      style: const TextStyle(fontSize: 10)),
-                                  const SizedBox(width: 4),
-                                  Expanded(
-                                    child: Text(
-                                      s.name + (isMe ? ' (YOU)' : ''),
-                                      maxLines: 1,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: TextStyle(
-                                        color: isMe
-                                            ? const Color(0xFF00D4FF)
-                                            : Colors.white,
-                                        fontWeight: isMe
-                                            ? FontWeight.w900
-                                            : FontWeight.w600,
-                                        fontSize: 11,
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: 6),
-                                  Text(
-                                    s.isAlive ? '${s.score}' : '💥',
-                                    style: TextStyle(
-                                      color: s.isAlive
-                                          ? const Color(0xFF00FF88)
-                                          : const Color(0xFFFF2A4B),
-                                      fontWeight: FontWeight.w900,
-                                      fontSize: 11,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            );
-                          }),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
+                ),
               ),
-            ),
-          ),
 
-          // Spectating / Crashed Overlay
-          if (_hasCrashed)
-            Positioned.fill(
-              child: Container(
-                color: Colors.black.withValues(alpha: 0.75),
-                child: Center(
+              // Bottom Mobile Controls (in portrait on mobile)
+              if (isMobile && isPortrait && !_hasCrashed)
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: _buildMobileControlBar(),
+                ),
+
+              // Spectating / Crashed Overlay
+              if (_hasCrashed)
+                Positioned.fill(
                   child: Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 28, vertical: 22),
-                    decoration: BoxDecoration(
-                      color: const Color(0xFF0A192F),
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                          color: const Color(0xFFFF2A4B), width: 1.5),
-                      boxShadow: [
-                        BoxShadow(
-                          color: const Color(0xFFFF2A4B).withValues(alpha: 0.3),
-                          blurRadius: 25,
-                        ),
-                      ],
-                    ),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        const Text(
-                          '💥 RUN CRASHED',
-                          style: TextStyle(
-                            color: Color(0xFFFF2A4B),
-                            fontSize: 24,
-                            fontWeight: FontWeight.w900,
-                            letterSpacing: 2.0,
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          'Final Score: $_finalScore • Patches: $_finalPatches',
-                          style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                              fontWeight: FontWeight.bold),
-                        ),
-                        const SizedBox(height: 16),
-                        const Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            SizedBox(
-                              width: 14,
-                              height: 14,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                valueColor: AlwaysStoppedAnimation<Color>(
-                                    Color(0xFF00D4FF)),
-                              ),
-                            ),
-                            SizedBox(width: 10),
-                            Text(
-                              'Awaiting race completion...',
-                              style: TextStyle(
-                                  color: Color(0xFF00D4FF), fontSize: 12),
+                    color: Colors.black.withValues(alpha: 0.75),
+                    child: Center(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 28, vertical: 22),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF0A192F),
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(
+                              color: const Color(0xFFFF2A4B), width: 1.5),
+                          boxShadow: [
+                            BoxShadow(
+                              color: const Color(0xFFFF2A4B)
+                                  .withValues(alpha: 0.3),
+                              blurRadius: 25,
                             ),
                           ],
                         ),
-                      ],
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Text(
+                              '💥 RUN CRASHED',
+                              style: TextStyle(
+                                color: Color(0xFFFF2A4B),
+                                fontSize: 24,
+                                fontWeight: FontWeight.w900,
+                                letterSpacing: 2.0,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Final Score: $_finalScore • Patches: $_finalPatches',
+                              style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: 16),
+                            const Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                SizedBox(
+                                  width: 14,
+                                  height: 14,
+                                  child: CircularProgressIndicator(
+                                    strokeWidth: 2,
+                                    valueColor: AlwaysStoppedAnimation<Color>(
+                                        Color(0xFF00D4FF)),
+                                  ),
+                                ),
+                                SizedBox(width: 10),
+                                Text(
+                                  'Awaiting race completion...',
+                                  style: TextStyle(
+                                      color: Color(0xFF00D4FF), fontSize: 12),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
                   ),
                 ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildMobileControlBar() {
+    return Container(
+      color: const Color(0xFF070B12).withValues(alpha: 0.88),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: _buildTouchButton(
+                label: 'LEFT',
+                icon: Icons.arrow_left,
+                color: const Color(0xFF00D4FF),
+                onTap: () => _game?.moveLeft(),
               ),
             ),
-        ],
+            const SizedBox(width: 6),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'MID',
+                icon: Icons.adjust,
+                color: const Color(0xFFFFC107),
+                onTap: () => _game?.moveToLane(1),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'RIGHT',
+                icon: Icons.arrow_right,
+                color: const Color(0xFF00D4FF),
+                onTap: () => _game?.moveRight(),
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'JUMP',
+                icon: Icons.keyboard_double_arrow_up,
+                color: const Color(0xFF00FF88),
+                onTap: () => _game?.jump(),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Expanded(
+              child: _buildTouchButton(
+                label: 'SLIDE',
+                icon: Icons.keyboard_double_arrow_down,
+                color: const Color(0xFFFF9100),
+                onTap: () => _game?.slide(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTouchButton({
+    required String label,
+    required IconData icon,
+    required Color color,
+    required VoidCallback onTap,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () {
+          AudioService.playSelect();
+          onTap();
+        },
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.14),
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: color.withValues(alpha: 0.45)),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, color: color, size: 18),
+              const SizedBox(height: 2),
+              Text(
+                label,
+                style: TextStyle(
+                  color: color,
+                  fontWeight: FontWeight.w900,
+                  fontSize: 10,
+                  letterSpacing: 1.0,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/shorebird_runner/lib/screens/tournament_podium_screen.dart
+++ b/shorebird_runner/lib/screens/tournament_podium_screen.dart
@@ -8,12 +8,14 @@ class TournamentPodiumScreen extends StatelessWidget {
   final List<RacerStanding> rankings;
   final VoidCallback onRematch;
   final VoidCallback onReturnToLobby;
+  final bool isHost;
 
   const TournamentPodiumScreen({
     super.key,
     required this.rankings,
     required this.onRematch,
     required this.onReturnToLobby,
+    this.isHost = false,
   });
 
   @override
@@ -187,59 +189,124 @@ class TournamentPodiumScreen extends StatelessWidget {
                       const SizedBox(height: 28),
 
                       // Action buttons
-                      Row(
-                        children: [
-                          Expanded(
-                            child: OutlinedButton.icon(
+                      if (isHost)
+                        Row(
+                          children: [
+                            Expanded(
+                              child: OutlinedButton.icon(
+                                onPressed: () {
+                                  AudioService.playSelect();
+                                  onReturnToLobby();
+                                },
+                                icon: const Icon(Icons.meeting_room,
+                                    color: Colors.white70),
+                                label: const Text('LEAVE ROOM',
+                                    style: TextStyle(letterSpacing: 1.5)),
+                                style: OutlinedButton.styleFrom(
+                                  foregroundColor: Colors.white,
+                                  side: const BorderSide(color: Colors.white24),
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 16),
+                                  shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(12)),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 16),
+                            Expanded(
+                              child: ElevatedButton.icon(
+                                onPressed: () {
+                                  AudioService.playSelect();
+                                  onRematch();
+                                },
+                                icon: const Icon(Icons.refresh,
+                                    color: Colors.black),
+                                label: const Text(
+                                  'REMATCH RACE',
+                                  style: TextStyle(
+                                    color: Colors.black,
+                                    fontWeight: FontWeight.w900,
+                                    letterSpacing: 1.5,
+                                  ),
+                                ),
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: const Color(0xFF00FF88),
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 16),
+                                  elevation: 8,
+                                  shadowColor: const Color(0xFF00FF88)
+                                      .withValues(alpha: 0.5),
+                                  shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(12)),
+                                ),
+                              ),
+                            ),
+                          ],
+                        )
+                      else
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 18, vertical: 14),
+                              decoration: BoxDecoration(
+                                color: const Color(0xFF0A192F)
+                                    .withValues(alpha: 0.9),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                    color: const Color(0xFF00D4FF)
+                                        .withValues(alpha: 0.4)),
+                              ),
+                              child: const Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  SizedBox(
+                                    width: 16,
+                                    height: 16,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: Color(0xFF00D4FF),
+                                    ),
+                                  ),
+                                  SizedBox(width: 12),
+                                  Text(
+                                    'WAITING FOR ROOM OWNER TO REMATCH...',
+                                    style: TextStyle(
+                                      color: Color(0xFF00D4FF),
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: 12,
+                                      letterSpacing: 1.2,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 14),
+                            OutlinedButton.icon(
                               onPressed: () {
                                 AudioService.playSelect();
                                 onReturnToLobby();
                               },
-                              icon: const Icon(Icons.meeting_room,
-                                  color: Colors.white70),
-                              label: const Text('BACK TO LOBBY',
-                                  style: TextStyle(letterSpacing: 1.5)),
+                              icon: const Icon(Icons.exit_to_app,
+                                  color: Color(0xFFFF2A4B)),
+                              label: const Text('LEAVE ROOM',
+                                  style: TextStyle(
+                                    letterSpacing: 1.5,
+                                    color: Color(0xFFFF2A4B),
+                                    fontWeight: FontWeight.bold,
+                                  )),
                               style: OutlinedButton.styleFrom(
-                                foregroundColor: Colors.white,
-                                side: const BorderSide(color: Colors.white24),
+                                side:
+                                    const BorderSide(color: Color(0xFFFF2A4B)),
                                 padding:
                                     const EdgeInsets.symmetric(vertical: 16),
                                 shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.circular(12)),
                               ),
                             ),
-                          ),
-                          const SizedBox(width: 16),
-                          Expanded(
-                            child: ElevatedButton.icon(
-                              onPressed: () {
-                                AudioService.playSelect();
-                                onRematch();
-                              },
-                              icon: const Icon(Icons.refresh,
-                                  color: Colors.black),
-                              label: const Text(
-                                'REMATCH RACE',
-                                style: TextStyle(
-                                  color: Colors.black,
-                                  fontWeight: FontWeight.w900,
-                                  letterSpacing: 1.5,
-                                ),
-                              ),
-                              style: ElevatedButton.styleFrom(
-                                backgroundColor: const Color(0xFF00FF88),
-                                padding:
-                                    const EdgeInsets.symmetric(vertical: 16),
-                                elevation: 8,
-                                shadowColor: const Color(0xFF00FF88)
-                                    .withValues(alpha: 0.5),
-                                shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12)),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
+                          ],
+                        ),
                     ],
                   ),
                 ),

--- a/shorebird_runner/lib/services/lobby_service.dart
+++ b/shorebird_runner/lib/services/lobby_service.dart
@@ -90,6 +90,8 @@ class LobbyService extends ChangeNotifier {
 
   WebSocketChannel? _channel;
   StreamSubscription? _sub;
+  final _rematchStreamController = StreamController<void>.broadcast();
+  Stream<void> get onRematchTriggered => _rematchStreamController.stream;
 
   bool _isConnected = false;
   bool get isConnected => _isConnected;
@@ -310,6 +312,11 @@ class LobbyService extends ChangeNotifier {
     notifyListeners();
   }
 
+  void requestRematch() {
+    if (!isHost) return;
+    _send({'type': 'rematch'});
+  }
+
   void _send(Map<String, dynamic> msg) {
     if (_channel != null && _isConnected) {
       _channel!.sink.add(jsonEncode(msg));
@@ -379,6 +386,15 @@ class LobbyService extends ChangeNotifier {
           notifyListeners();
           break;
 
+        case 'room_rematch':
+          _isRacing = false;
+          _countdown = 0;
+          _finalRankings = null;
+          _parseRoom(json['room'] as Map<String, dynamic>?);
+          notifyListeners();
+          _rematchStreamController.add(null);
+          break;
+
         case 'error':
           _errorMessage = json['message'] as String?;
           notifyListeners();
@@ -402,6 +418,7 @@ class LobbyService extends ChangeNotifier {
   void dispose() {
     _sub?.cancel();
     _channel?.sink.close();
+    _rematchStreamController.close();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- **Mobile Fullscreen**: Removed the rigid `AspectRatio(800 / 600)` wrapper and fixed card borders on mobile/narrow screens in both solo mode (`main.dart`) and tournament race mode (`multiplayer_race_screen.dart`). The canvas now expands to fill 100% of the mobile screen.
- **Direct Lane Tap Steering**: Players can now simply tap directly on any lane (left third, center third, or right third of the screen) to immediately steer the character to that lane without needing to swipe or slide.
- **Mobile Tactile Control Bar**: In portrait mode on phones, an intuitive quick-action control bar (`LEFT`, `MID`, `RIGHT`, `JUMP`, `SLIDE`) is provided at the bottom of the screen.
- **Host-Only Rematch Flow**:
  - Rematch action is now strictly restricted to the room owner/host on the podium screen.
  - Participants see a clean `WAITING FOR ROOM OWNER TO REMATCH...` indicator along with a prominent `LEAVE ROOM` button if they wish to exit.
  - Added server-side `rematch` message handler in `lobby_server.dart` that resets player states and broadcasts `room_rematch` to all room participants simultaneously.
  - Client subscribes to `onRematchTriggered` stream so all players return to the room lobby in sync when the host initiates a rematch.
- **CI & Testing**: Added conditional imports for `AudioService` (`audio_service_web.dart` and `audio_service_stub.dart`) to ensure `flutter test` and `shorebird_ci` pass on Dart VM test runners.