### PR TITLE
feat(shorebird_runner): game polish, 120 FPS mobile performance, and web stability

### DIFF
--- a/shorebird_runner/lib/game/components/components.dart
+++ b/shorebird_runner/lib/game/components/components.dart
@@ -10,5 +10,6 @@ export 'player.dart';
 export 'player_skin.dart';
 export 'shooting_star.dart';
 export 'sparkle.dart';
+export 'speed_warp_fx.dart';
 export 'star.dart';
 export 'starfield.dart';

--- a/shorebird_runner/lib/game/components/hud.dart
+++ b/shorebird_runner/lib/game/components/hud.dart
@@ -87,6 +87,14 @@ class Hud extends Component {
   final Paint _comboBgPaint = Paint();
   final Paint _comboBorderPaint = Paint()..style = PaintingStyle.stroke;
 
+  // Pre-allocated banner paints & cached shaders for zero-allocation rendering
+  final Paint _bannerGlowPaint = Paint()..style = PaintingStyle.stroke;
+  final Paint _bannerBgPaint = Paint();
+  final Paint _bannerBorderPaint = Paint()..style = PaintingStyle.stroke;
+  late final Shader _borderShader;
+  late final Shader _borderMissShader;
+  int _lastProgressLevel = -1;
+
   Hud({this.playerTag}) {
     _initStaticPainters();
     _updateScorePainter();
@@ -100,6 +108,57 @@ class Hud extends Component {
       text: const TextSpan(text: '🐤', style: TextStyle(fontSize: 18)),
       textDirection: TextDirection.ltr,
     )..layout();
+
+    final panelRect = Rect.fromLTWH(0, 0, GameConfig.designWidth, 68);
+    _bgPaint.shader = const LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        Color(0xF00D111A),
+        Color(0xF007090F),
+      ],
+    ).createShader(panelRect);
+
+    final sheenRect = Rect.fromLTWH(0, 0, GameConfig.designWidth, 18);
+    _sheenPaint.shader = const LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        Color(0x14FFFFFF),
+        Color(0x00FFFFFF),
+      ],
+    ).createShader(sheenRect);
+
+    final borderRect = Rect.fromLTWH(0, 67, GameConfig.designWidth, 1.5);
+    _borderShader = LinearGradient(
+      colors: [
+        _shorebirdGold.withValues(alpha: 0.0),
+        _shorebirdGold.withValues(alpha: 0.9),
+        _shorebirdGold.withValues(alpha: 0.0),
+      ],
+    ).createShader(borderRect);
+    _borderPaint.shader = _borderShader;
+
+    _borderMissShader = LinearGradient(
+      colors: [
+        const Color(0xFFFF3D57).withValues(alpha: 0.0),
+        const Color(0xFFFF3D57).withValues(alpha: 0.9),
+        const Color(0xFFFF3D57).withValues(alpha: 0.0),
+      ],
+    ).createShader(borderRect);
+
+    const bannerW = 500.0;
+    const bannerH = 120.0;
+    final bannerRect =
+        Rect.fromCenter(center: Offset.zero, width: bannerW, height: bannerH);
+    _bannerBgPaint.shader = const LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [
+        Color(0xF8111520),
+        Color(0xF80C0F18),
+      ],
+    ).createShader(bannerRect);
   }
 
   void _updateScorePainter() {
@@ -290,41 +349,18 @@ class Hud extends Component {
 
   void _drawTopPanel(Canvas canvas) {
     final isMissing = _missFlash > 0;
-    final accentColor = isMissing ? const Color(0xFFFF3D57) : _shorebirdGold;
 
-    // Panel background — deep navy with subtle gradient
+    // Panel background — deep navy with subtle gradient (cached shader)
     final panelRect = Rect.fromLTWH(0, 0, GameConfig.designWidth, 68);
-    _bgPaint.shader = const LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [
-        Color(0xF00D111A),
-        Color(0xF007090F),
-      ],
-    ).createShader(panelRect);
     canvas.drawRect(panelRect, _bgPaint);
 
-    // Top sheen
+    // Top sheen (cached shader)
     final sheenRect = Rect.fromLTWH(0, 0, GameConfig.designWidth, 18);
-    _sheenPaint.shader = const LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [
-        Color(0x14FFFFFF),
-        Color(0x00FFFFFF),
-      ],
-    ).createShader(sheenRect);
     canvas.drawRect(sheenRect, _sheenPaint);
 
-    // Shorebird gold bottom border
+    // Shorebird gold bottom border (cached shader)
     final borderRect = Rect.fromLTWH(0, 67, GameConfig.designWidth, 1.5);
-    _borderPaint.shader = LinearGradient(
-      colors: [
-        accentColor.withValues(alpha: 0.0),
-        accentColor.withValues(alpha: 0.9),
-        accentColor.withValues(alpha: 0.0),
-      ],
-    ).createShader(borderRect);
+    _borderPaint.shader = isMissing ? _borderMissShader : _borderShader;
     canvas.drawRect(borderRect, _borderPaint);
 
     // Miss flash overlay
@@ -367,16 +403,9 @@ class Hud extends Component {
     const barY = 67.5;
     const barH = 3.5;
 
-    // Track
-    canvas.drawRect(
-      Rect.fromLTWH(0, barY, GameConfig.designWidth, barH),
-      _trackPaint,
-    );
-
-    // Fill with accent gradient
-    if (fraction > 0) {
-      final fillW = GameConfig.designWidth * fraction;
-      final fillRect = Rect.fromLTWH(0, barY, fillW, barH);
+    // Cache gradient shader only when tier changes
+    if (_lastProgressLevel != curLevel.level) {
+      _lastProgressLevel = curLevel.level;
       _progressFillPaint.shader = LinearGradient(
         colors: [
           accent.withValues(alpha: 0.6),
@@ -384,7 +413,19 @@ class Hud extends Component {
           const Color(0xFFFFFFFF),
         ],
         stops: const [0.0, 0.75, 1.0],
-      ).createShader(fillRect);
+      ).createShader(Rect.fromLTWH(0, barY, GameConfig.designWidth, barH));
+    }
+
+    // Track
+    canvas.drawRect(
+      Rect.fromLTWH(0, barY, GameConfig.designWidth, barH),
+      _trackPaint,
+    );
+
+    // Fill with accent gradient (zero allocations)
+    if (fraction > 0) {
+      final fillW = GameConfig.designWidth * fraction;
+      final fillRect = Rect.fromLTWH(0, barY, fillW, barH);
       canvas.drawRect(fillRect, _progressFillPaint);
 
       // Progress glow orb without expensive blur pass
@@ -441,33 +482,22 @@ class Hud extends Component {
     final rrect = RRect.fromRectAndRadius(rect, const Radius.circular(20));
     final accent = Color(level.accentColor);
 
-    // Multi-layer crisp ambient glow (no expensive blur pass)
-    final glowPaint = Paint()..style = PaintingStyle.stroke;
-    glowPaint.color = accent.withValues(alpha: 0.15 * alpha);
-    glowPaint.strokeWidth = 10;
-    canvas.drawRRect(rrect, glowPaint);
-    glowPaint.color = accent.withValues(alpha: 0.35 * alpha);
-    glowPaint.strokeWidth = 4;
-    canvas.drawRRect(rrect, glowPaint);
+    // Multi-layer crisp ambient glow (zero allocations)
+    _bannerGlowPaint.color = accent.withValues(alpha: 0.15 * alpha);
+    _bannerGlowPaint.strokeWidth = 10;
+    canvas.drawRRect(rrect, _bannerGlowPaint);
+    _bannerGlowPaint.color = accent.withValues(alpha: 0.35 * alpha);
+    _bannerGlowPaint.strokeWidth = 4;
+    canvas.drawRRect(rrect, _bannerGlowPaint);
 
-    // Background
-    final bgPaint = Paint()
-      ..shader = const LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: [
-          Color(0xF8111520),
-          Color(0xF80C0F18),
-        ],
-      ).createShader(rect);
-    canvas.drawRRect(rrect, bgPaint);
+    // Background (pre-cached shader)
+    canvas.drawRRect(rrect, _bannerBgPaint);
 
-    // Border
-    final borderPaint = Paint()
+    // Border (reusable paint)
+    _bannerBorderPaint
       ..color = accent.withValues(alpha: 0.9 * alpha)
-      ..strokeWidth = 2
-      ..style = PaintingStyle.stroke;
-    canvas.drawRRect(rrect, borderPaint);
+      ..strokeWidth = 2;
+    canvas.drawRRect(rrect, _bannerBorderPaint);
 
     // Render text
     if (_tpBannerTitle != null) {

--- a/shorebird_runner/lib/game/components/hud.dart
+++ b/shorebird_runner/lib/game/components/hud.dart
@@ -69,7 +69,6 @@ class Hud extends Component {
   TextPainter? _tpScoreValue;
   TextPainter? _tpNextLabel;
   TextPainter? _tpNextValue;
-  TextPainter? _tpLogo;
   TextPainter? _tpCombo;
   TextPainter? _tpBannerTitle;
   TextPainter? _tpBannerName;
@@ -95,6 +94,16 @@ class Hud extends Component {
   late final Shader _borderMissShader;
   int _lastProgressLevel = -1;
 
+  // Vector bird logo paints & paths (zero web font dependency)
+  static final Paint _birdBodyPaint = Paint()..color = const Color(0xFFFFD54F);
+  static final Paint _birdWingPaint = Paint()..color = const Color(0xFFFFB300);
+  static final Paint _birdEyePaint = Paint()..color = const Color(0xFF0F172A);
+  static final Paint _birdEyeGlint = Paint()..color = const Color(0xFFFFFFFF);
+  static final Paint _birdBeakPaint = Paint()..color = const Color(0xFFFF5722);
+  static final Paint _birdCrestPaint = Paint()..color = const Color(0xFFFFB300);
+  static final Path _beakPath = Path();
+  static final Path _crestPath = Path();
+
   Hud({this.playerTag}) {
     _initStaticPainters();
     _updateScorePainter();
@@ -104,11 +113,6 @@ class Hud extends Component {
   }
 
   void _initStaticPainters() {
-    _tpLogo = TextPainter(
-      text: const TextSpan(text: '🐤', style: TextStyle(fontSize: 18)),
-      textDirection: TextDirection.ltr,
-    )..layout();
-
     final panelRect = Rect.fromLTWH(0, 0, GameConfig.designWidth, 68);
     _bgPaint.shader = const LinearGradient(
       begin: Alignment.topCenter,
@@ -217,7 +221,7 @@ class Hud extends Component {
 
       _tpPlanName = TextPainter(
         text: TextSpan(
-          text: '${curLevel.emoji}  ${curLevel.name}',
+          text: curLevel.name,
           style: const TextStyle(
             color: _shorebirdGold,
             fontSize: 16,
@@ -232,8 +236,8 @@ class Hud extends Component {
     final nextLvl = GameConfig.nextLevel(_totalPatches);
     final patchesInLevel = _totalPatches - curLevel.patchThreshold;
     final nextText = nextLvl != null
-        ? '$patchesInLevel / ${curLevel.patchesNeeded}  🐤'
-        : 'ENTERPRISE  👑';
+        ? '$patchesInLevel / ${curLevel.patchesNeeded}  PATCHES'
+        : 'ENTERPRISE  TIER';
     final nextLabel = nextLvl != null ? 'NEXT: ${nextLvl.name}' : 'MAX TIER';
 
     _tpNextLabel = TextPainter(
@@ -267,7 +271,7 @@ class Hud extends Component {
     if (_combo > 1) {
       _tpCombo = TextPainter(
         text: TextSpan(
-          text: '🔥  STREAK  ×$_combo',
+          text: 'STREAK  ×$_combo',
           style: const TextStyle(
             color: Color(0xFFFFE082),
             fontSize: 11,
@@ -289,7 +293,7 @@ class Hud extends Component {
 
     _tpBannerTitle = TextPainter(
       text: const TextSpan(
-        text: '🚀  PLAN UPGRADED  ·  LEVEL UP!',
+        text: 'PLAN UPGRADED  ·  LEVEL UP!',
         style: TextStyle(
           color: _shorebirdGold,
           fontSize: 12,
@@ -302,7 +306,7 @@ class Hud extends Component {
 
     _tpBannerName = TextPainter(
       text: TextSpan(
-        text: '${newLevel.emoji}  ${newLevel.name}  PLAN',
+        text: '${newLevel.name}  PLAN',
         style: TextStyle(
           color: Color(newLevel.accentColor),
           fontSize: 26,
@@ -392,8 +396,48 @@ class Hud extends Component {
     _tpNextLabel?.paint(canvas, Offset(GameConfig.designWidth - 178, 10));
     _tpNextValue?.paint(canvas, Offset(GameConfig.designWidth - 178, 26));
 
-    // 🐤 Shorebird logo mark on the far right
-    _tpLogo?.paint(canvas, Offset(GameConfig.designWidth - 30, 24));
+    // Vector Shorebird logo mark on far right (zero font dependency)
+    _drawVectorLogo(canvas, Offset(GameConfig.designWidth - 28, 34));
+  }
+
+  void _drawVectorLogo(Canvas canvas, Offset center) {
+    canvas.save();
+    canvas.translate(center.dx, center.dy);
+    const s = 18.0 / 24.0;
+    canvas.scale(s, s);
+
+    // Head/Body
+    canvas.drawCircle(const Offset(0, 0), 10.5, _birdBodyPaint);
+
+    // Crest
+    _crestPath
+      ..reset()
+      ..moveTo(0, -10.5)
+      ..quadraticBezierTo(2, -15, 6, -14)
+      ..quadraticBezierTo(2, -11, 1, -8.5)
+      ..close();
+    canvas.drawPath(_crestPath, _birdCrestPaint);
+
+    // Wing
+    canvas.drawOval(
+      Rect.fromCenter(center: const Offset(-2.5, 2.0), width: 11, height: 8),
+      _birdWingPaint,
+    );
+
+    // Beak
+    _beakPath
+      ..reset()
+      ..moveTo(8.5, -2)
+      ..lineTo(14.5, 0.5)
+      ..lineTo(8, 3.5)
+      ..close();
+    canvas.drawPath(_beakPath, _birdBeakPaint);
+
+    // Eye & Glint
+    canvas.drawCircle(const Offset(3.5, -2.5), 2.2, _birdEyePaint);
+    canvas.drawCircle(const Offset(4.2, -3.2), 0.8, _birdEyeGlint);
+
+    canvas.restore();
   }
 
   void _drawStageProgressBar(Canvas canvas) {

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -9,6 +9,7 @@ import 'package:shorebird_runner/game/utils/utils.dart';
 /// Optimized for steady 120 FPS with pre-baked window geometry and cached text.
 class LaneWorld extends Component {
   int totalPatches = 0;
+  bool isInvincible = false;
   double _scroll = 0;
 
   Offset get _nearLeft => Offset(
@@ -353,7 +354,8 @@ class LaneWorld extends Component {
 
   @override
   void update(double dt) {
-    final speed = GameConfig.scrollSpeed(totalPatches);
+    final speed =
+        GameConfig.scrollSpeed(totalPatches, isInvincible: isInvincible);
     _scroll = (_scroll + dt * speed * 0.45) % 1.0;
     _searchlightAngle += dt * 0.85;
 

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -44,6 +44,12 @@ class LaneWorld extends Component {
   final Path _amberWindowsPath = Path();
   final Path _cyanWindowsPath = Path();
 
+  // Reusable paths for zero-allocation rendering loops
+  final Path _segmentPath = Path();
+  final Path _chevronPath = Path();
+  final Path _refPath = Path();
+  final Path _searchlightBeamPath = Path();
+
   // Cached TextPainters for Billboards & Gantry
   final Map<String, TextPainter> _cachedBillboards = {};
   final List<TextPainter> _cachedGantryTexts = [];
@@ -64,7 +70,6 @@ class LaneWorld extends Component {
     ..color = const Color(0xFF00E5FF).withValues(alpha: 0.7)
     ..style = PaintingStyle.fill;
   final Paint _bldFillPaint = Paint()..style = PaintingStyle.fill;
-  final Paint _refPaint = Paint()..style = PaintingStyle.fill;
   final Paint _tilePaint = Paint()..style = PaintingStyle.fill;
   final Paint _seamPaint = Paint();
   final Paint _chevronPaint = Paint()
@@ -82,9 +87,42 @@ class LaneWorld extends Component {
   final Paint _railBasePaint = Paint();
   final Paint _railSheenPaint = Paint();
   final Paint _trussPaint = Paint();
-  final Paint _boardBgPaint = Paint()..style = PaintingStyle.fill;
+  final Paint _boardBgPaint = Paint()
+    ..color = const Color(0xFF070B14)
+    ..style = PaintingStyle.fill;
   final Paint _boardBorderPaint = Paint()..style = PaintingStyle.stroke;
   final Paint _bracketPaint = Paint()..style = PaintingStyle.stroke;
+
+  // Cached ambient & billboard paints
+  final Paint _searchlightPaintCyan = Paint();
+  final Paint _searchlightPaintAmber = Paint();
+  final Paint _bloomPaint = Paint();
+  final Paint _horizonGlowPaint = Paint()..strokeWidth = 2.8;
+  final Paint _towerPaint = Paint();
+  final Paint _bbBgPaint = Paint()
+    ..color = const Color(0xFF050B14)
+    ..style = PaintingStyle.fill;
+  final Paint _bbBorderPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.2;
+  final Paint _beaconGlow = Paint();
+  final Paint _beaconMid = Paint();
+  final Paint _beaconCore = Paint()..color = const Color(0xFFFFFFFF);
+  final List<Paint> _refPaints =
+      List.generate(5, (_) => Paint()..style = PaintingStyle.fill);
+
+  final List<double> _lanePulses = [0.0, 0.0, 0.0];
+  final Path _lanePulsePath = Path();
+  final Paint _lanePulsePaint = Paint()..style = PaintingStyle.fill;
+  final Paint _lanePulseBorderPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 2.0;
+
+  void triggerLanePulse(int lane) {
+    if (lane >= 0 && lane < 3) {
+      _lanePulses[lane] = 1.0;
+    }
+  }
 
   @override
   Future<void> onLoad() async {
@@ -177,7 +215,110 @@ class LaneWorld extends Component {
         }
       }
     }
+
+    // Pre-cache landscape and architectural shaders
+    _mountainPaint.shader = const LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFF0F0826), Color(0xFF060312)],
+    ).createShader(Rect.fromLTWH(0, 0, w, cy));
+
+    _bldFillPaint.shader = const LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFF0D1826), Color(0xFF040810)],
+    ).createShader(Rect.fromLTWH(0, 0, w, cy));
+
+    _towerPaint.shader = const LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [Color(0xFF09061A), Color(0xFF04020C)],
+    ).createShader(Rect.fromLTWH(0, 0, w, cy));
+
+    _searchlightPaintCyan.shader = LinearGradient(
+      begin: Alignment.bottomCenter,
+      end: Alignment.topCenter,
+      colors: [
+        const Color(0xFF00E5FF).withValues(alpha: 0.22),
+        const Color(0xFF00E5FF).withValues(alpha: 0.0),
+      ],
+    ).createShader(const Rect.fromLTWH(-50, -140, 100, 140));
+
+    _searchlightPaintAmber.shader = LinearGradient(
+      begin: Alignment.bottomCenter,
+      end: Alignment.topCenter,
+      colors: [
+        const Color(0xFFFFB300).withValues(alpha: 0.22),
+        const Color(0xFFFFB300).withValues(alpha: 0.0),
+      ],
+    ).createShader(const Rect.fromLTWH(-50, -140, 100, 140));
+
+    const refColors = [
+      Color(0xFF00E5FF),
+      Color(0xFFFF8F00),
+      Color(0xFFFFC107),
+      Color(0xFF00FFCC),
+      Color(0xFF38BDF8),
+    ];
+    for (int i = 0; i < 5; i++) {
+      _refPaints[i].shader = LinearGradient(
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+        colors: [
+          refColors[i].withValues(alpha: 0.15),
+          refColors[i].withValues(alpha: 0.07),
+          refColors[i].withValues(alpha: 0.0),
+        ],
+        stops: const [0.0, 0.55, 1.0],
+      ).createShader(Rect.fromLTWH(0, cy, w, GameConfig.nearY - cy));
+    }
+
+    _updateThemeShaders();
   }
+
+  void _updateThemeShaders() {
+    final cy = GameConfig.horizonY;
+    final w = GameConfig.designWidth;
+
+    _hazePaint.shader = LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        _curHorizonColor.withValues(alpha: 0.0),
+        _curHorizonColor.withValues(alpha: 0.40),
+        const Color(0xFF030712),
+      ],
+      stops: const [0.0, 0.65, 1.0],
+    ).createShader(Rect.fromLTWH(0, cy * 0.2, w, cy * 0.8));
+
+    _bloomPaint.shader = RadialGradient(
+      colors: [
+        _curAccentColor.withValues(alpha: 0.55),
+        _curAccentColor.withValues(alpha: 0.20),
+        const Color(0x00000000),
+      ],
+      stops: const [0.0, 0.45, 1.0],
+    ).createShader(
+      Rect.fromCircle(
+        center: Offset(GameConfig.vanishingX, cy),
+        radius: 110,
+      ),
+    );
+
+    _horizonGlowPaint.shader = LinearGradient(
+      colors: [
+        _curAccentColor.withValues(alpha: 0),
+        _curAccentColor.withValues(alpha: 0.95),
+        const Color(0xFFFFFFFF),
+        _curAccentColor.withValues(alpha: 0.95),
+        _curAccentColor.withValues(alpha: 0),
+      ],
+    ).createShader(
+      Rect.fromLTRB(_farLeft.dx - 160, cy, _farRight.dx + 160, cy),
+    );
+  }
+
+  int _lastShaderLevel = -1;
 
   void _initCachedTextPainters() {
     // Billboards
@@ -234,6 +375,12 @@ class LaneWorld extends Component {
     _scroll = (_scroll + dt * speed * 0.45) % 1.0;
     _searchlightAngle += dt * 0.85;
 
+    for (int i = 0; i < 3; i++) {
+      if (_lanePulses[i] > 0) {
+        _lanePulses[i] = (_lanePulses[i] - dt * 3.5).clamp(0.0, 1.0);
+      }
+    }
+
     final targetLevel = GameConfig.levelFor(totalPatches);
     final targetAccent = Color(targetLevel.accentColor);
     final targetRoad = Color(targetLevel.roadColor);
@@ -242,6 +389,11 @@ class LaneWorld extends Component {
     _curAccentColor = Color.lerp(_curAccentColor, targetAccent, dt * 2.5)!;
     _curRoadColor = Color.lerp(_curRoadColor, targetRoad, dt * 2.5)!;
     _curHorizonColor = Color.lerp(_curHorizonColor, targetHorizon, dt * 2.5)!;
+
+    if (_lastShaderLevel != targetLevel.level) {
+      _lastShaderLevel = targetLevel.level;
+      _updateThemeShaders();
+    }
   }
 
   @override
@@ -251,8 +403,36 @@ class LaneWorld extends Component {
     _drawSubwayRails(canvas);
     _drawLaneDividers(canvas);
     _drawGuardRails(canvas);
+    _drawLanePulses(canvas);
     _draw3DPylons(canvas);
     _drawPlanGantry(canvas);
+  }
+
+  void _drawLanePulses(Canvas canvas) {
+    for (int l = 0; l < 3; l++) {
+      final pulse = _lanePulses[l];
+      if (pulse <= 0.01) continue;
+
+      final pNearL = _lerpRoadPoint(l / 3.0, 0.98);
+      final pNearR = _lerpRoadPoint((l + 1.0) / 3.0, 0.98);
+      final pFarR = _lerpRoadPoint((l + 1.0) / 3.0, 0.62);
+      final pFarL = _lerpRoadPoint(l / 3.0, 0.62);
+
+      _lanePulsePath
+        ..reset()
+        ..moveTo(pNearL.dx, pNearL.dy)
+        ..lineTo(pNearR.dx, pNearR.dy)
+        ..lineTo(pFarR.dx, pFarR.dy)
+        ..lineTo(pFarL.dx, pFarL.dy)
+        ..close();
+
+      _lanePulsePaint.color = _curAccentColor.withValues(alpha: pulse * 0.32);
+      canvas.drawPath(_lanePulsePath, _lanePulsePaint);
+
+      _lanePulseBorderPaint.color =
+          const Color(0xFFFFFFFF).withValues(alpha: pulse * 0.75);
+      canvas.drawPath(_lanePulsePath, _lanePulseBorderPaint);
+    }
   }
 
   void _drawCinematicCityscape(Canvas canvas) {
@@ -260,44 +440,29 @@ class LaneWorld extends Component {
     final w = GameConfig.designWidth;
     final isDesktop = w > GameConfig.designHeight;
 
-    // 1. Distant Mountain Ridge Silhouettes against Twilight Sky
-    _mountainPaint.shader = const LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [Color(0xFF0F0826), Color(0xFF060312)],
-    ).createShader(Rect.fromLTWH(0, 0, w, cy));
+    // 1. Distant Mountain Ridge Silhouettes against Twilight Sky (cached shader)
     canvas.drawPath(_mountainPath, _mountainPaint);
 
     // 2. Deep Atmospheric Horizon Fog Haze
-    _hazePaint.shader = LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [
-        _curHorizonColor.withValues(alpha: 0.0),
-        _curHorizonColor.withValues(alpha: 0.40),
-        const Color(0xFF030712),
-      ],
-      stops: const [0.0, 0.65, 1.0],
-    ).createShader(Rect.fromLTWH(0, cy * 0.2, w, cy * 0.8));
     canvas.drawRect(
       Rect.fromLTWH(0, cy * 0.2, w, cy * 0.8),
       _hazePaint,
     );
 
-    // 3. Sweeping Hollywood / Los Santos Searchlight Beams
+    // 3. Sweeping Hollywood / Los Santos Searchlight Beams (zero allocations)
     _drawSearchlight(
       canvas,
       w * 0.22,
       cy,
       _searchlightAngle,
-      const Color(0xFF00E5FF),
+      _searchlightPaintCyan,
     );
     _drawSearchlight(
       canvas,
       w * 0.78,
       cy,
       -_searchlightAngle * 0.9 + 1.2,
-      const Color(0xFFFFB300),
+      _searchlightPaintAmber,
     );
 
     // 4. Distant Giant Spire Towers (scaled relative to sky height)
@@ -306,58 +471,24 @@ class LaneWorld extends Component {
     _drawDistantTower(canvas, w * 0.64, cy, 36, towerHeight * 1.1);
 
     // 5. Pre-baked Skyscraper Silhouettes & Lit Window Paths (Zero loop allocations!)
-    _bldFillPaint.shader = const LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [Color(0xFF0D1826), Color(0xFF040810)],
-    ).createShader(Rect.fromLTWH(0, 0, w, cy));
     canvas.drawPath(_skylineBuildingsPath, _bldFillPaint);
-
     canvas.drawPath(_amberWindowsPath, _amberWinPaint);
     canvas.drawPath(_cyanWindowsPath, _cyanWinPaint);
 
     // Billboards & Rooftop Antennas
     _drawRooftopElements(canvas, cy);
 
-    // 6. Horizon Vanishing Point Volumetric Lens Bloom
-    final bloomPaint = Paint()
-      ..shader = RadialGradient(
-        colors: [
-          _curAccentColor.withValues(alpha: 0.55),
-          _curAccentColor.withValues(alpha: 0.20),
-          const Color(0x00000000),
-        ],
-        stops: const [0.0, 0.45, 1.0],
-      ).createShader(
-        Rect.fromCircle(
-          center: Offset(GameConfig.vanishingX, cy),
-          radius: 110,
-        ),
-      );
-    canvas.drawCircle(Offset(GameConfig.vanishingX, cy), 110, bloomPaint);
+    // 6. Horizon Vanishing Point Volumetric Lens Bloom (cached paint)
+    canvas.drawCircle(Offset(GameConfig.vanishingX, cy), 110, _bloomPaint);
 
     // 7. Glowing Horizon Laser Neon Line
-    final horizonGlow = Paint()
-      ..shader = LinearGradient(
-        colors: [
-          _curAccentColor.withValues(alpha: 0),
-          _curAccentColor.withValues(alpha: 0.95),
-          const Color(0xFFFFFFFF),
-          _curAccentColor.withValues(alpha: 0.95),
-          _curAccentColor.withValues(alpha: 0),
-        ],
-      ).createShader(
-        Rect.fromLTRB(_farLeft.dx - 160, cy, _farRight.dx + 160, cy),
-      )
-      ..strokeWidth = 2.8;
-
     canvas.drawLine(
       Offset(_farLeft.dx - 160, cy),
       Offset(_farRight.dx + 160, cy),
-      horizonGlow,
+      _horizonGlowPaint,
     );
 
-    // 8. Wet asphalt specular road reflections
+    // 8. Wet asphalt specular road reflections (zero allocations)
     _drawWetRoadReflections(canvas);
   }
 
@@ -406,19 +537,12 @@ class LaneWorld extends Component {
   ) {
     final bbY = topY - 14;
     final bbRect = Rect.fromLTWH(x - 2, bbY, w + 4, 12);
+    final rrect = RRect.fromRectAndRadius(bbRect, const Radius.circular(2));
 
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(bbRect, const Radius.circular(2)),
-      Paint()..color = const Color(0xFF050B14),
-    );
+    canvas.drawRRect(rrect, _bbBgPaint);
 
-    canvas.drawRRect(
-      RRect.fromRectAndRadius(bbRect, const Radius.circular(2)),
-      Paint()
-        ..color = borderColor.withValues(alpha: 0.85)
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 1.2,
-    );
+    _bbBorderPaint.color = borderColor.withValues(alpha: 0.85);
+    canvas.drawRRect(rrect, _bbBorderPaint);
 
     final tp = _cachedBillboards[text];
     if (tp != null) {
@@ -434,21 +558,14 @@ class LaneWorld extends Component {
     canvas.drawLine(Offset(x, baseY), Offset(x, baseY - antH), _antPaint);
     final beaconFlash = sin(_searchlightAngle * 4 + seed) > 0.0;
     if (beaconFlash) {
-      canvas.drawCircle(
-        Offset(x, baseY - antH),
-        3.5,
-        Paint()..color = const Color(0x66FF2A4B),
-      );
-      canvas.drawCircle(
-        Offset(x, baseY - antH),
-        1.8,
-        Paint()..color = const Color(0xFFFF2A4B),
-      );
-      canvas.drawCircle(
-        Offset(x, baseY - antH),
-        1.0,
-        Paint()..color = const Color(0xFFFFFFFF),
-      );
+      final tip = Offset(x, baseY - antH);
+      _beaconGlow.color = const Color(0x66FF2A4B);
+      canvas.drawCircle(tip, 3.5, _beaconGlow);
+
+      _beaconMid.color = const Color(0xFFFF2A4B);
+      canvas.drawCircle(tip, 1.8, _beaconMid);
+
+      canvas.drawCircle(tip, 1.0, _beaconCore);
     }
   }
 
@@ -460,22 +577,17 @@ class LaneWorld extends Component {
     double h,
   ) {
     final rect = Rect.fromLTWH(x - w * 0.5, baseY - h, w, h);
-    final paint = Paint()
-      ..shader = const LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [Color(0xFF09061A), Color(0xFF04020C)],
-      ).createShader(rect);
-    canvas.drawRect(rect, paint);
+    canvas.drawRect(rect, _towerPaint);
     canvas.drawLine(
       Offset(x, baseY - h),
       Offset(x, baseY - h - 35),
       _spirePaint,
     );
+    _beaconMid.color = const Color(0xFFFF2A4B);
     canvas.drawCircle(
       Offset(x, baseY - h - 35),
       2.5,
-      Paint()..color = const Color(0xFFFF2A4B),
+      _beaconMid,
     );
   }
 
@@ -484,66 +596,40 @@ class LaneWorld extends Component {
     double x,
     double y,
     double angle,
-    Color color,
+    Paint beamPaint,
   ) {
     canvas.save();
     canvas.translate(x, y);
-    final beamPath = Path()
+    _searchlightBeamPath
+      ..reset()
       ..moveTo(0, 0)
       ..lineTo(sin(angle) * 70 - 24, -140)
       ..lineTo(sin(angle) * 70 + 24, -140)
       ..close();
-    final beamPaint = Paint()
-      ..shader = LinearGradient(
-        begin: Alignment.bottomCenter,
-        end: Alignment.topCenter,
-        colors: [
-          color.withValues(alpha: 0.22),
-          color.withValues(alpha: 0.0),
-        ],
-      ).createShader(const Rect.fromLTWH(-50, -140, 100, 140));
-    canvas.drawPath(beamPath, beamPaint);
+    canvas.drawPath(_searchlightBeamPath, beamPaint);
     canvas.restore();
   }
 
   void _drawWetRoadReflections(Canvas canvas) {
-    const reflections = [
-      (0.20, Color(0xFF00E5FF)),
-      (0.35, Color(0xFFFF8F00)),
-      (0.50, Color(0xFFFFC107)),
-      (0.65, Color(0xFF00FFCC)),
-      (0.80, Color(0xFF38BDF8)),
-    ];
+    const reflections = [0.20, 0.35, 0.50, 0.65, 0.80];
 
-    for (final ref in reflections) {
-      final xFrac = ref.$1;
-      final color = ref.$2;
-
+    for (int i = 0; i < reflections.length; i++) {
+      final xFrac = reflections[i];
       final pFar = _lerpRoadPoint(xFrac, 0.05);
       final pNear = _lerpRoadPoint(xFrac, 0.95);
 
       const widthFar = 4.0;
       const widthNear = 28.0;
 
-      final refPath = Path()
+      _refPath
+        ..reset()
         ..moveTo(pFar.dx - widthFar / 2, pFar.dy)
         ..lineTo(pFar.dx + widthFar / 2, pFar.dy)
         ..lineTo(pNear.dx + widthNear / 2, pNear.dy)
         ..lineTo(pNear.dx - widthNear / 2, pNear.dy)
         ..close();
 
-      _refPaint.shader = LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [
-          color.withValues(alpha: 0.15),
-          color.withValues(alpha: 0.07),
-          color.withValues(alpha: 0.0),
-        ],
-        stops: const [0.0, 0.55, 1.0],
-      ).createShader(Rect.fromPoints(pFar, pNear));
-
-      canvas.drawPath(refPath, _refPaint);
+      canvas.drawPath(_refPath, _refPaints[i]);
     }
   }
 
@@ -563,7 +649,8 @@ class LaneWorld extends Component {
       final pFarR = _lerpRoadPoint(1, tFar);
       final pFarL = _lerpRoadPoint(0, tFar);
 
-      final path = Path()
+      _segmentPath
+        ..reset()
         ..moveTo(pNearL.dx, pNearL.dy)
         ..lineTo(pNearR.dx, pNearR.dy)
         ..lineTo(pFarR.dx, pFarR.dy)
@@ -577,7 +664,7 @@ class LaneWorld extends Component {
           : Color.lerp(_curRoadColor, const Color(0xFF020710), 0.5)!;
 
       _tilePaint.color = baseColor.withValues(alpha: segmentAlpha);
-      canvas.drawPath(path, _tilePaint);
+      canvas.drawPath(_segmentPath, _tilePaint);
 
       _seamPaint
         ..color =
@@ -591,7 +678,8 @@ class LaneWorld extends Component {
         final chW = (16.0 * tNear).clamp(3.0, 24.0);
         final chH = (8.0 * tNear).clamp(2.0, 12.0);
 
-        final chevronPath = Path()
+        _chevronPath
+          ..reset()
           ..moveTo(chevronCenter.dx - chW, chevronCenter.dy + chH)
           ..lineTo(chevronCenter.dx, chevronCenter.dy - chH * 0.4)
           ..lineTo(chevronCenter.dx + chW, chevronCenter.dy + chH);
@@ -601,7 +689,7 @@ class LaneWorld extends Component {
               _curAccentColor.withValues(alpha: (tNear * 0.45).clamp(0.0, 0.45))
           ..strokeWidth = (1.2 + tNear * 2.0);
 
-        canvas.drawPath(chevronPath, _chevronPaint);
+        canvas.drawPath(_chevronPath, _chevronPaint);
       }
     }
   }

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -13,22 +13,22 @@ class LaneWorld extends Component {
 
   Offset get _nearLeft => Offset(
         GameConfig.nearLaneX[0] -
-            (GameConfig.nearLaneX[1] - GameConfig.nearLaneX[0]) * 0.65,
+            (GameConfig.nearLaneX[1] - GameConfig.nearLaneX[0]) * 0.5,
         GameConfig.nearY + 20,
       );
   Offset get _nearRight => Offset(
         GameConfig.nearLaneX[2] +
-            (GameConfig.nearLaneX[2] - GameConfig.nearLaneX[1]) * 0.65,
+            (GameConfig.nearLaneX[2] - GameConfig.nearLaneX[1]) * 0.5,
         GameConfig.nearY + 20,
       );
   Offset get _farLeft => Offset(
         GameConfig.farLaneX[0] -
-            (GameConfig.farLaneX[1] - GameConfig.farLaneX[0]) * 0.45,
+            (GameConfig.farLaneX[1] - GameConfig.farLaneX[0]) * 0.5,
         GameConfig.horizonY,
       );
   Offset get _farRight => Offset(
         GameConfig.farLaneX[2] +
-            (GameConfig.farLaneX[2] - GameConfig.farLaneX[1]) * 0.45,
+            (GameConfig.farLaneX[2] - GameConfig.farLaneX[1]) * 0.5,
         GameConfig.horizonY,
       );
 
@@ -83,9 +83,6 @@ class LaneWorld extends Component {
     ..strokeWidth = 1.5
     ..style = PaintingStyle.stroke;
   final Paint _postPaint = Paint()..strokeCap = StrokeCap.round;
-  final Paint _tiePaint = Paint()..strokeCap = StrokeCap.square;
-  final Paint _railBasePaint = Paint();
-  final Paint _railSheenPaint = Paint();
   final Paint _trussPaint = Paint();
   final Paint _boardBgPaint = Paint()
     ..color = const Color(0xFF070B14)
@@ -109,7 +106,7 @@ class LaneWorld extends Component {
   final Paint _beaconMid = Paint();
   final Paint _beaconCore = Paint()..color = const Color(0xFFFFFFFF);
   final List<Paint> _refPaints =
-      List.generate(5, (_) => Paint()..style = PaintingStyle.fill);
+      List.generate(3, (_) => Paint()..style = PaintingStyle.fill);
 
   @override
   Future<void> onLoad() async {
@@ -242,12 +239,10 @@ class LaneWorld extends Component {
 
     const refColors = [
       Color(0xFF00E5FF),
-      Color(0xFFFF8F00),
       Color(0xFFFFC107),
       Color(0xFF00FFCC),
-      Color(0xFF38BDF8),
     ];
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 3; i++) {
       _refPaints[i].shader = LinearGradient(
         begin: Alignment.topCenter,
         end: Alignment.bottomCenter,
@@ -381,7 +376,6 @@ class LaneWorld extends Component {
   void render(Canvas canvas) {
     _drawCinematicCityscape(canvas);
     _drawRoadSegments(canvas);
-    _drawSubwayRails(canvas);
     _drawLaneDividers(canvas);
     _drawGuardRails(canvas);
     _draw3DPylons(canvas);
@@ -564,7 +558,7 @@ class LaneWorld extends Component {
   }
 
   void _drawWetRoadReflections(Canvas canvas) {
-    const reflections = [0.20, 0.35, 0.50, 0.65, 0.80];
+    const reflections = [1.0 / 6.0, 0.50, 5.0 / 6.0];
 
     for (int i = 0; i < reflections.length; i++) {
       final xFrac = reflections[i];
@@ -660,10 +654,10 @@ class LaneWorld extends Component {
         final p1 = _lerpRoadPoint(laneFrac, t1);
         final p2 = _lerpRoadPoint(laneFrac, t2);
 
-        final dashAlpha = (t1 * 0.75).clamp(0.0, 0.75);
+        final dashAlpha = (t1 * 0.9).clamp(0.15, 0.95);
         _dashPaint
           ..color = _curAccentColor.withValues(alpha: dashAlpha)
-          ..strokeWidth = 1.0 + t1 * 2.5;
+          ..strokeWidth = 2.0 + t1 * 3.5;
 
         canvas.drawLine(p1, p2, _dashPaint);
       }
@@ -749,55 +743,6 @@ class LaneWorld extends Component {
       width * 0.35,
       Paint()..color = const Color(0xFFFFFFFF).withValues(alpha: alpha),
     );
-  }
-
-  void _drawSubwayRails(Canvas canvas) {
-    for (int lane = 0; lane < GameConfig.laneCount; lane++) {
-      final centerFrac = (lane + 0.5) / GameConfig.laneCount;
-      const railHalfWidth = 0.085;
-      final leftFrac = centerFrac - railHalfWidth;
-      final rightFrac = centerFrac + railHalfWidth;
-
-      // Cross ties
-      const ties = 14;
-      for (int i = 0; i < ties; i++) {
-        final tRaw = ((i / ties) + _scroll) % 1.0;
-        final t = pow(tRaw, 1.8).toDouble();
-        final pL = _lerpRoadPoint(leftFrac - 0.02, t);
-        final pR = _lerpRoadPoint(rightFrac + 0.02, t);
-        final tieAlpha = (t * 0.55).clamp(0.0, 0.55);
-        _tiePaint
-          ..color = const Color(0xFF1E293B).withValues(alpha: tieAlpha)
-          ..strokeWidth = 2.5 + t * 4.5;
-        canvas.drawLine(pL, pR, _tiePaint);
-      }
-
-      // Rails
-      const railSegments = 20;
-      for (int i = 0; i < railSegments; i++) {
-        final t1 = pow(i / railSegments, 1.8).toDouble();
-        final t2 = pow((i + 1) / railSegments, 1.8).toDouble();
-
-        final pL1 = _lerpRoadPoint(leftFrac, t1);
-        final pL2 = _lerpRoadPoint(leftFrac, t2);
-        final pR1 = _lerpRoadPoint(rightFrac, t1);
-        final pR2 = _lerpRoadPoint(rightFrac, t2);
-
-        final railAlpha = (t2 * 0.85).clamp(0.1, 0.85);
-
-        _railBasePaint
-          ..color = const Color(0xFF475569).withValues(alpha: railAlpha)
-          ..strokeWidth = 1.2 + t2 * 3.5;
-        canvas.drawLine(pL1, pL2, _railBasePaint);
-        canvas.drawLine(pR1, pR2, _railBasePaint);
-
-        _railSheenPaint
-          ..color = const Color(0xFFFFFFFF).withValues(alpha: railAlpha * 0.75)
-          ..strokeWidth = 0.8 + t2 * 1.5;
-        canvas.drawLine(pL1, pL2, _railSheenPaint);
-        canvas.drawLine(pR1, pR2, _railSheenPaint);
-      }
-    }
   }
 
   void _drawPlanGantry(Canvas canvas) {

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -717,34 +717,22 @@ class LaneWorld extends Component {
     );
 
     _postPaint
-      ..shader = LinearGradient(
-        begin: Alignment.bottomCenter,
-        end: Alignment.topCenter,
-        colors: [
-          const Color(0xFF0A192F).withValues(alpha: alpha),
-          _curAccentColor.withValues(alpha: alpha),
-        ],
-      ).createShader(Rect.fromPoints(base, top))
+      ..shader = null
+      ..color = Color.lerp(const Color(0xFF0A192F), _curAccentColor, 0.45)!
+          .withValues(alpha: alpha)
       ..strokeWidth = width * 0.6;
     canvas.drawLine(base, top, _postPaint);
 
-    // Multi-ring concentric beacon glow (replaces expensive blur pass)
+    // Multi-ring concentric beacon glow (zero per-frame allocations)
     final beaconColor = _curAccentColor.withValues(alpha: alpha);
-    canvas.drawCircle(
-      top,
-      width * 1.2,
-      Paint()..color = beaconColor.withValues(alpha: alpha * 0.25),
-    );
-    canvas.drawCircle(
-      top,
-      width * 0.7,
-      Paint()..color = beaconColor.withValues(alpha: alpha * 0.7),
-    );
-    canvas.drawCircle(
-      top,
-      width * 0.35,
-      Paint()..color = const Color(0xFFFFFFFF).withValues(alpha: alpha),
-    );
+    _beaconGlow.color = beaconColor.withValues(alpha: alpha * 0.25);
+    canvas.drawCircle(top, width * 1.2, _beaconGlow);
+
+    _beaconMid.color = beaconColor.withValues(alpha: alpha * 0.7);
+    canvas.drawCircle(top, width * 0.7, _beaconMid);
+
+    _beaconCore.color = const Color(0xFFFFFFFF).withValues(alpha: alpha);
+    canvas.drawCircle(top, width * 0.35, _beaconCore);
   }
 
   void _drawPlanGantry(Canvas canvas) {
@@ -781,14 +769,9 @@ class LaneWorld extends Component {
       height: boardH,
     );
 
-    _boardBgPaint.shader = LinearGradient(
-      begin: Alignment.topCenter,
-      end: Alignment.bottomCenter,
-      colors: [
-        const Color(0xFF0F172A).withValues(alpha: alpha * 0.95),
-        const Color(0xFF020617).withValues(alpha: alpha * 0.95),
-      ],
-    ).createShader(boardRect);
+    _boardBgPaint
+      ..shader = null
+      ..color = const Color(0xFF0A1324).withValues(alpha: alpha * 0.95);
     canvas.drawRRect(
       RRect.fromRectAndRadius(boardRect, Radius.circular(4 * t)),
       _boardBgPaint,

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -329,10 +329,10 @@ class LaneWorld extends Component {
 
     // Gantry Quota Texts
     const tiers = [
-      '⚡ HOBBY · 5,000 PATCHES',
-      '⚡ PRO · 50,000 PATCHES',
-      '⚡ BUSINESS · 1,000,000 PATCHES',
-      '⚡ ENTERPRISE · CUSTOM PATCHES',
+      'HOBBY · 5,000 PATCHES',
+      'PRO · 50,000 PATCHES',
+      'BUSINESS · 1,000,000 PATCHES',
+      'ENTERPRISE · CUSTOM PATCHES',
     ];
 
     for (final t in tiers) {

--- a/shorebird_runner/lib/game/components/lane_world.dart
+++ b/shorebird_runner/lib/game/components/lane_world.dart
@@ -111,19 +111,6 @@ class LaneWorld extends Component {
   final List<Paint> _refPaints =
       List.generate(5, (_) => Paint()..style = PaintingStyle.fill);
 
-  final List<double> _lanePulses = [0.0, 0.0, 0.0];
-  final Path _lanePulsePath = Path();
-  final Paint _lanePulsePaint = Paint()..style = PaintingStyle.fill;
-  final Paint _lanePulseBorderPaint = Paint()
-    ..style = PaintingStyle.stroke
-    ..strokeWidth = 2.0;
-
-  void triggerLanePulse(int lane) {
-    if (lane >= 0 && lane < 3) {
-      _lanePulses[lane] = 1.0;
-    }
-  }
-
   @override
   Future<void> onLoad() async {
     _initStaticGeometry();
@@ -375,12 +362,6 @@ class LaneWorld extends Component {
     _scroll = (_scroll + dt * speed * 0.45) % 1.0;
     _searchlightAngle += dt * 0.85;
 
-    for (int i = 0; i < 3; i++) {
-      if (_lanePulses[i] > 0) {
-        _lanePulses[i] = (_lanePulses[i] - dt * 3.5).clamp(0.0, 1.0);
-      }
-    }
-
     final targetLevel = GameConfig.levelFor(totalPatches);
     final targetAccent = Color(targetLevel.accentColor);
     final targetRoad = Color(targetLevel.roadColor);
@@ -403,36 +384,8 @@ class LaneWorld extends Component {
     _drawSubwayRails(canvas);
     _drawLaneDividers(canvas);
     _drawGuardRails(canvas);
-    _drawLanePulses(canvas);
     _draw3DPylons(canvas);
     _drawPlanGantry(canvas);
-  }
-
-  void _drawLanePulses(Canvas canvas) {
-    for (int l = 0; l < 3; l++) {
-      final pulse = _lanePulses[l];
-      if (pulse <= 0.01) continue;
-
-      final pNearL = _lerpRoadPoint(l / 3.0, 0.98);
-      final pNearR = _lerpRoadPoint((l + 1.0) / 3.0, 0.98);
-      final pFarR = _lerpRoadPoint((l + 1.0) / 3.0, 0.62);
-      final pFarL = _lerpRoadPoint(l / 3.0, 0.62);
-
-      _lanePulsePath
-        ..reset()
-        ..moveTo(pNearL.dx, pNearL.dy)
-        ..lineTo(pNearR.dx, pNearR.dy)
-        ..lineTo(pFarR.dx, pFarR.dy)
-        ..lineTo(pFarL.dx, pFarL.dy)
-        ..close();
-
-      _lanePulsePaint.color = _curAccentColor.withValues(alpha: pulse * 0.32);
-      canvas.drawPath(_lanePulsePath, _lanePulsePaint);
-
-      _lanePulseBorderPaint.color =
-          const Color(0xFFFFFFFF).withValues(alpha: pulse * 0.75);
-      canvas.drawPath(_lanePulsePath, _lanePulseBorderPaint);
-    }
   }
 
   void _drawCinematicCityscape(Canvas canvas) {

--- a/shorebird_runner/lib/game/components/magnetic_trail_particle.dart
+++ b/shorebird_runner/lib/game/components/magnetic_trail_particle.dart
@@ -31,16 +31,15 @@ class MagneticTrailParticle {
     life = (life - dt * 4.0).clamp(0.0, 1.0);
   }
 
+  static final Paint _outerPaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _innerPaint = Paint()..style = PaintingStyle.fill;
+
   void render(Canvas canvas) {
     if (life <= 0) return;
-    final outerPaint = Paint()
-      ..color = color.withValues(alpha: life * 0.35)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(pos, radius * life * 1.8, outerPaint);
+    _outerPaint.color = color.withValues(alpha: life * 0.35);
+    canvas.drawCircle(pos, radius * life * 1.8, _outerPaint);
 
-    final innerPaint = Paint()
-      ..color = color.withValues(alpha: life * 0.90)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(pos, radius * life, innerPaint);
+    _innerPaint.color = color.withValues(alpha: life * 0.90);
+    canvas.drawCircle(pos, radius * life, _innerPaint);
   }
 }

--- a/shorebird_runner/lib/game/components/obstacle.dart
+++ b/shorebird_runner/lib/game/components/obstacle.dart
@@ -16,6 +16,7 @@ class Obstacle extends Component {
   final double _rotationPhase;
   bool isDead = false;
   int totalPatches = 0;
+  bool isInvincible = false;
 
   bool get isJumpable =>
       type == ObstacleType.wormBug || type == ObstacleType.mergeBarricade;
@@ -44,7 +45,8 @@ class Obstacle extends Component {
 
   @override
   void update(double dt) {
-    final speed = GameConfig.scrollSpeed(totalPatches);
+    final speed =
+        GameConfig.scrollSpeed(totalPatches, isInvincible: isInvincible);
     depth += dt * speed * 0.54;
   }
 

--- a/shorebird_runner/lib/game/components/obstacle.dart
+++ b/shorebird_runner/lib/game/components/obstacle.dart
@@ -80,6 +80,202 @@ class Obstacle extends Component {
     }
   }
 
+  static final Paint _shadowOuterPaint = Paint();
+  static final Paint _shadowInnerPaint = Paint();
+
+  // App Store static assets
+  static const Rect _appBoxRect = Rect.fromLTWH(-50, -50, 100, 100);
+  static final RRect _appUnitRRect =
+      RRect.fromRectAndRadius(_appBoxRect, const Radius.circular(23));
+  static const Rect _appSheenRect = Rect.fromLTWH(-46, -43, 92, 42);
+  static final RRect _appSheenUnitRRect =
+      RRect.fromRectAndRadius(_appSheenRect, const Radius.circular(18));
+
+  static final Paint _appHaloOuterPaint = Paint();
+  static final Paint _appHaloInnerPaint = Paint();
+
+  static final Paint _appBgPaint = Paint()
+    ..shader = const LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        Color(0xFF1E90FF),
+        Color(0xFF0071E3),
+        Color(0xFF0040DD),
+      ],
+      stops: [0.0, 0.55, 1.0],
+    ).createShader(_appBoxRect)
+    ..style = PaintingStyle.fill;
+
+  static final Paint _appSheenPaint = Paint()
+    ..shader = LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [
+        Colors.white.withValues(alpha: 0.35),
+        Colors.white.withValues(alpha: 0.0),
+      ],
+    ).createShader(_appSheenRect)
+    ..style = PaintingStyle.fill;
+
+  static final Paint _appBorderPaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _appAPaint = Paint()
+    ..color = Colors.white
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+  static final Paint _appJointPaint = Paint()..color = const Color(0xFF0071E3);
+
+  // Play Store static assets
+  static final Paint _playHaloOuterPaint = Paint();
+  static final Paint _playHaloInnerPaint = Paint();
+
+  static final Path _playBluePath = Path()
+    ..moveTo(-42, -44)
+    ..lineTo(-42, 44)
+    ..lineTo(5, 0)
+    ..close();
+
+  static final Path _playGreenPath = Path()
+    ..moveTo(-42, -44)
+    ..lineTo(5, 0)
+    ..lineTo(46, 0)
+    ..close();
+
+  static final Path _playYellowPath = Path()
+    ..moveTo(46, 0)
+    ..lineTo(5, 0)
+    ..lineTo(-12, 32)
+    ..close();
+
+  static final Path _playRedPath = Path()
+    ..moveTo(-42, 44)
+    ..lineTo(5, 0)
+    ..lineTo(46, 0)
+    ..lineTo(-42, 44)
+    ..close();
+
+  static final Path _playOuterPath = Path()
+    ..moveTo(-42, -44)
+    ..lineTo(46, 0)
+    ..lineTo(-42, 44)
+    ..close();
+
+  static final Paint _playBluePaint = Paint()
+    ..shader = const LinearGradient(
+      colors: [Color(0xFF00C6FF), Color(0xFF0072FF)],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    ).createShader(const Rect.fromLTWH(-42, -44, 47, 44))
+    ..style = PaintingStyle.fill;
+
+  static final Paint _playGreenPaint = Paint()
+    ..shader = const LinearGradient(
+      colors: [Color(0xFF00F5A0), Color(0xFF00D95A)],
+      begin: Alignment.topCenter,
+      end: Alignment.bottomRight,
+    ).createShader(const Rect.fromLTWH(-42, -44, 88, 44))
+    ..style = PaintingStyle.fill;
+
+  static final Paint _playYellowPaint = Paint()
+    ..shader = const LinearGradient(
+      colors: [Color(0xFFFFDD00), Color(0xFFFF9900)],
+      begin: Alignment.topRight,
+      end: Alignment.bottomCenter,
+    ).createShader(const Rect.fromLTWH(5, 0, 41, 32))
+    ..style = PaintingStyle.fill;
+
+  static final Paint _playRedPaint = Paint()
+    ..shader = const LinearGradient(
+      colors: [Color(0xFFFF4E50), Color(0xFFF9D423)],
+      begin: Alignment.bottomLeft,
+      end: Alignment.topRight,
+    ).createShader(const Rect.fromLTWH(-42, 0, 88, 44))
+    ..style = PaintingStyle.fill;
+
+  static final Paint _playBorderPaint = Paint()
+    ..color = Colors.white.withValues(alpha: 0.3)
+    ..style = PaintingStyle.stroke;
+
+  // Worm Bug static assets
+  static final Paint _wormHeadBodyPaint = Paint()
+    ..shader = const RadialGradient(
+      colors: [
+        Color(0xFF86EFAC),
+        Color(0xFF22C55E),
+        Color(0xFF052E16),
+      ],
+      center: Alignment(-0.25, -0.35),
+    ).createShader(const Rect.fromLTWH(-50, -50, 100, 100))
+    ..style = PaintingStyle.fill;
+
+  static final Paint _wormBodyPaint = Paint()
+    ..shader = const RadialGradient(
+      colors: [
+        Color(0xFF86EFAC),
+        Color(0xFF16A34A),
+        Color(0xFF052E16),
+      ],
+      center: Alignment(-0.25, -0.35),
+    ).createShader(const Rect.fromLTWH(-50, -50, 100, 100))
+    ..style = PaintingStyle.fill;
+
+  static final Paint _wormSpotPaint = Paint()
+    ..color = const Color(0xFFFACC15).withValues(alpha: 0.85);
+  static final Paint _wormFootPaint = Paint()..color = const Color(0xFF15803D);
+  static final Paint _wormAntennaPaint = Paint()
+    ..color = const Color(0xFF15803D)
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+  static final Paint _wormAntennaTipPaint = Paint()
+    ..color = const Color(0xFFFF4E50);
+  static final Paint _wormWhitePaint = Paint()..color = Colors.white;
+  static final Paint _wormBlackPaint = Paint()..color = Colors.black;
+  static final Paint _wormBlushPaint = Paint()
+    ..color = const Color(0xFFFF69B4).withValues(alpha: 0.6);
+  static final Paint _wormMouthPaint = Paint()
+    ..color = const Color(0xFF052E16)
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+
+  static final Path _reusableLeftAntenna = Path();
+  static final Path _reusableRightAntenna = Path();
+  static final Path _reusableMouth = Path();
+
+  // Merge Barricade static assets
+  static final Paint _barricadeLegPaint = Paint()
+    ..color = const Color(0xFF334155)
+    ..style = PaintingStyle.stroke;
+  static final Paint _barricadeRailPaint = Paint()
+    ..color = const Color(0xFFFFB300);
+  static final Paint _barricadeStripePaint = Paint()
+    ..color = const Color(0xFF1E293B)
+    ..style = PaintingStyle.stroke;
+  static final Paint _beaconGlowPaint = Paint();
+  static final Paint _beaconCorePaint = Paint();
+
+  // Review Gate static assets
+  static final Paint _gatePostPaint = Paint()
+    ..color = const Color(0xFF1E293B)
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+  static final Paint _gateNeonLinePaint = Paint()
+    ..color = const Color(0xFF00E5FF).withValues(alpha: 0.8)
+    ..style = PaintingStyle.stroke;
+  static final Paint _gateCrossbarBgPaint = Paint()
+    ..color = const Color(0xFF0F172A);
+  static final Paint _gateCrossbarBorderPaint = Paint()
+    ..color = const Color(0xFFFFC107).withValues(alpha: 0.7)
+    ..style = PaintingStyle.stroke;
+  static final Paint _gateLaserGlowPaint = Paint()
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+  static final Paint _gateLaserCorePaint = Paint()
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+  static final Paint _gateLaserFilamentPaint = Paint()
+    ..strokeCap = StrokeCap.round
+    ..style = PaintingStyle.stroke;
+
   // ── 🍎 Apple App Store Logo Obstacle ───────────────────────────────────────
   void _drawAppStore(Canvas canvas, Offset pos, double scale, double size) {
     final hoverBob = sin(_wobblePhase + depth * 6) * 4 * scale;
@@ -87,21 +283,25 @@ class Obstacle extends Component {
 
     // Dual-concentric ground shadow (zero blur, butter smooth)
     final shadowCenter = Offset(pos.dx, pos.dy + 8 * scale);
+    _shadowOuterPaint.color =
+        const Color(0xFF001133).withValues(alpha: 0.25 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: size * 1.25,
         height: 16 * scale,
       ),
-      Paint()..color = const Color(0xFF001133).withValues(alpha: 0.25 * scale),
+      _shadowOuterPaint,
     );
+    _shadowInnerPaint.color =
+        const Color(0xFF001133).withValues(alpha: 0.55 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: size * 0.92,
         height: 10 * scale,
       ),
-      Paint()..color = const Color(0xFF001133).withValues(alpha: 0.55 * scale),
+      _shadowInnerPaint,
     );
 
     canvas.save();
@@ -110,101 +310,81 @@ class Obstacle extends Component {
 
     final boxW = size * 0.96;
     final boxH = size * 0.96;
-    final boxRect =
-        Rect.fromCenter(center: Offset.zero, width: boxW, height: boxH);
-    final cornerRadius = Radius.circular(boxW * 0.23);
-    final rrect = RRect.fromRectAndRadius(boxRect, cornerRadius);
 
     // Neon Blue Stepped Ambient Halo (replaces MaskFilter.blur)
-    canvas.drawRRect(
-      rrect.inflate(8 * scale),
-      Paint()..color = const Color(0xFF0A84FF).withValues(alpha: 0.15 * scale),
+    _appHaloOuterPaint.color =
+        const Color(0xFF0A84FF).withValues(alpha: 0.15 * scale);
+    final haloOuterRect = Rect.fromCenter(
+      center: Offset.zero,
+      width: boxW + 16 * scale,
+      height: boxH + 16 * scale,
     );
     canvas.drawRRect(
-      rrect.inflate(3 * scale),
-      Paint()..color = const Color(0xFF0A84FF).withValues(alpha: 0.35 * scale),
+      RRect.fromRectAndRadius(
+        haloOuterRect,
+        Radius.circular(boxW * 0.23 + 8 * scale),
+      ),
+      _appHaloOuterPaint,
     );
 
-    // App Store Signature Blue Gradient
-    final bgPaint = Paint()
-      ..shader = const LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [
-          Color(0xFF1E90FF),
-          Color(0xFF0071E3),
-          Color(0xFF0040DD),
-        ],
-        stops: [0.0, 0.55, 1.0],
-      ).createShader(boxRect)
-      ..style = PaintingStyle.fill;
-    canvas.drawRRect(rrect, bgPaint);
-
-    // Subtle Glass Top Sheen
-    final sheenRect = Rect.fromCenter(
-      center: Offset(0, -boxH * 0.22),
-      width: boxW * 0.92,
-      height: boxH * 0.42,
+    _appHaloInnerPaint.color =
+        const Color(0xFF0A84FF).withValues(alpha: 0.35 * scale);
+    final haloInnerRect = Rect.fromCenter(
+      center: Offset.zero,
+      width: boxW + 6 * scale,
+      height: boxH + 6 * scale,
     );
-    final sheenPaint = Paint()
-      ..shader = LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [
-          Colors.white.withValues(alpha: 0.35),
-          Colors.white.withValues(alpha: 0.0),
-        ],
-      ).createShader(sheenRect)
-      ..style = PaintingStyle.fill;
     canvas.drawRRect(
-      RRect.fromRectAndRadius(sheenRect, Radius.circular(boxW * 0.18)),
-      sheenPaint,
+      RRect.fromRectAndRadius(
+        haloInnerRect,
+        Radius.circular(boxW * 0.23 + 3 * scale),
+      ),
+      _appHaloInnerPaint,
     );
+
+    // App Store Signature Blue Gradient (rendered via unit scale)
+    canvas.save();
+    canvas.scale(boxW / 100, boxH / 100);
+    canvas.drawRRect(_appUnitRRect, _appBgPaint);
+    canvas.drawRRect(_appSheenUnitRRect, _appSheenPaint);
 
     // Outer Crisp Border
-    final borderPaint = Paint()
+    _appBorderPaint
       ..color = const Color(0xFF80BFFF).withValues(alpha: 0.65)
-      ..strokeWidth = 2.0 * scale
-      ..style = PaintingStyle.stroke;
-    canvas.drawRRect(rrect, borderPaint);
+      ..strokeWidth = (2.0 * scale) * (100 / boxW);
+    canvas.drawRRect(_appUnitRRect, _appBorderPaint);
 
     // Apple App Store "A" Logo (Pencil, Ruler, Brush bars)
-    final aStrokeW = boxW * 0.11;
-    final aPaint = Paint()
-      ..color = Colors.white
-      ..strokeWidth = aStrokeW
-      ..strokeCap = StrokeCap.round
-      ..style = PaintingStyle.stroke;
-
-    final topPeakY = -boxH * 0.26;
-    final bottomY = boxH * 0.26;
-    final legLeftX = -boxW * 0.26;
-    final legRightX = boxW * 0.26;
-    final crossY = boxH * 0.06;
+    const aStrokeW = 11.0;
+    _appAPaint.strokeWidth = aStrokeW;
 
     canvas.drawLine(
-      Offset(-boxW * 0.03, topPeakY),
-      Offset(legLeftX, bottomY),
-      aPaint,
+      const Offset(-3.0, -26.0),
+      const Offset(-26.0, 26.0),
+      _appAPaint,
     );
     canvas.drawLine(
-      Offset(boxW * 0.03, topPeakY),
-      Offset(legRightX, bottomY),
-      aPaint,
+      const Offset(3.0, -26.0),
+      const Offset(26.0, 26.0),
+      _appAPaint,
     );
     canvas.drawLine(
-      Offset(-boxW * 0.28, crossY),
-      Offset(boxW * 0.28, crossY),
-      aPaint,
+      const Offset(-28.0, 6.0),
+      const Offset(28.0, 6.0),
+      _appAPaint,
     );
 
-    final jointPaint = Paint()..color = const Color(0xFF0071E3);
     canvas.drawCircle(
-      Offset(-boxW * 0.14, crossY),
+      const Offset(-14.0, 6.0),
       aStrokeW * 0.22,
-      jointPaint,
+      _appJointPaint,
     );
-    canvas.drawCircle(Offset(boxW * 0.14, crossY), aStrokeW * 0.22, jointPaint);
+    canvas.drawCircle(
+      const Offset(14.0, 6.0),
+      aStrokeW * 0.22,
+      _appJointPaint,
+    );
+    canvas.restore();
 
     canvas.restore();
   }
@@ -216,122 +396,63 @@ class Obstacle extends Component {
 
     // Dual-concentric ground shadow
     final shadowCenter = Offset(pos.dx, pos.dy + 8 * scale);
+    _shadowOuterPaint.color =
+        const Color(0xFF000000).withValues(alpha: 0.25 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: size * 1.25,
         height: 16 * scale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: 0.25 * scale),
+      _shadowOuterPaint,
     );
+    _shadowInnerPaint.color =
+        const Color(0xFF000000).withValues(alpha: 0.55 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: size * 0.92,
         height: 10 * scale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: 0.55 * scale),
+      _shadowInnerPaint,
     );
 
     canvas.save();
     canvas.translate(pos.dx, centerY);
 
     // Multi-hue stepped halo (replaces blur)
+    _playHaloOuterPaint.color =
+        const Color(0xFF00E676).withValues(alpha: 0.15 * scale);
     canvas.drawCircle(
       Offset.zero,
       size * 0.62,
-      Paint()..color = const Color(0xFF00E676).withValues(alpha: 0.15 * scale),
+      _playHaloOuterPaint,
     );
+    _playHaloInnerPaint.color =
+        const Color(0xFF00E676).withValues(alpha: 0.32 * scale);
     canvas.drawCircle(
       Offset.zero,
       size * 0.52,
-      Paint()..color = const Color(0xFF00E676).withValues(alpha: 0.32 * scale),
+      _playHaloInnerPaint,
     );
 
     final w = size * 0.92;
     final h = size * 0.98;
 
-    final pTopLeft = Offset(-w * 0.42, -h * 0.44);
-    final pBottomLeft = Offset(-w * 0.42, h * 0.44);
-    final pRightTip = Offset(w * 0.46, 0);
-    final pCenter = Offset(w * 0.05, 0);
+    // 4 Facets drawn using static unit paths and pre-baked shaders
+    canvas.save();
+    canvas.scale(w / 100, h / 100);
 
-    // 1. Blue Facet (Top-Left)
-    final bluePath = Path()
-      ..moveTo(pTopLeft.dx, pTopLeft.dy)
-      ..lineTo(pBottomLeft.dx, pBottomLeft.dy)
-      ..lineTo(pCenter.dx, pCenter.dy)
-      ..close();
-    final bluePaint = Paint()
-      ..shader = const LinearGradient(
-        colors: [Color(0xFF00C6FF), Color(0xFF0072FF)],
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-      ).createShader(Rect.fromPoints(pTopLeft, pCenter))
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(bluePath, bluePaint);
+    canvas.drawPath(_playBluePath, _playBluePaint);
+    canvas.drawPath(_playGreenPath, _playGreenPaint);
+    canvas.drawPath(_playYellowPath, _playYellowPaint);
+    canvas.drawPath(_playRedPath, _playRedPaint);
+    canvas.drawPath(_playBluePath, _playBluePaint);
 
-    // 2. Green Facet (Top-Right)
-    final greenPath = Path()
-      ..moveTo(pTopLeft.dx, pTopLeft.dy)
-      ..lineTo(pCenter.dx, pCenter.dy)
-      ..lineTo(pRightTip.dx, pRightTip.dy)
-      ..close();
-    final greenPaint = Paint()
-      ..shader = const LinearGradient(
-        colors: [Color(0xFF00F5A0), Color(0xFF00D95A)],
-        begin: Alignment.topCenter,
-        end: Alignment.bottomRight,
-      ).createShader(Rect.fromPoints(pTopLeft, pRightTip))
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(greenPath, greenPaint);
+    _playBorderPaint.strokeWidth = (1.5 * scale) * (100 / w);
+    canvas.drawPath(_playOuterPath, _playBorderPaint);
 
-    // 3. Yellow Facet (Bottom-Right)
-    final yellowPath = Path()
-      ..moveTo(pRightTip.dx, pRightTip.dy)
-      ..lineTo(pCenter.dx, pCenter.dy)
-      ..lineTo(pBottomLeft.dx + w * 0.3, h * 0.32)
-      ..close();
-    final yellowPaint = Paint()
-      ..shader = const LinearGradient(
-        colors: [Color(0xFFFFDD00), Color(0xFFFF9900)],
-        begin: Alignment.topRight,
-        end: Alignment.bottomCenter,
-      ).createShader(Rect.fromPoints(pCenter, pRightTip))
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(yellowPath, yellowPaint);
-
-    // 4. Red Facet (Bottom-Left)
-    final redPath = Path()
-      ..moveTo(pBottomLeft.dx, pBottomLeft.dy)
-      ..lineTo(pCenter.dx, pCenter.dy)
-      ..lineTo(pRightTip.dx, pRightTip.dy)
-      ..lineTo(pBottomLeft.dx, pBottomLeft.dy)
-      ..close();
-    final redPaint = Paint()
-      ..shader = const LinearGradient(
-        colors: [Color(0xFFFF4E50), Color(0xFFF9D423)],
-        begin: Alignment.bottomLeft,
-        end: Alignment.topRight,
-      ).createShader(Rect.fromPoints(pBottomLeft, pRightTip))
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(redPath, redPaint);
-
-    canvas.drawPath(bluePath, bluePaint);
-
-    // Outer Crisp Edge
-    final outerPath = Path()
-      ..moveTo(pTopLeft.dx, pTopLeft.dy)
-      ..lineTo(pRightTip.dx, pRightTip.dy)
-      ..lineTo(pBottomLeft.dx, pBottomLeft.dy)
-      ..close();
-    canvas.drawPath(
-      outerPath,
-      Paint()
-        ..color = Colors.white.withValues(alpha: 0.3)
-        ..strokeWidth = 1.5 * scale
-        ..style = PaintingStyle.stroke,
-    );
+    canvas.restore();
 
     canvas.restore();
   }
@@ -343,21 +464,25 @@ class Obstacle extends Component {
 
     // Dual-concentric ground shadow
     final shadowCenter = Offset(pos.dx, pos.dy + 4 * scale);
+    _shadowOuterPaint.color =
+        const Color(0xFF000000).withValues(alpha: 0.22 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: size * 1.3,
         height: 14 * scale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: 0.22 * scale),
+      _shadowOuterPaint,
     );
+    _shadowInnerPaint.color =
+        const Color(0xFF000000).withValues(alpha: 0.52 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: size * 0.95,
         height: 8 * scale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: 0.52 * scale),
+      _shadowInnerPaint,
     );
 
     const segmentCount = 5;
@@ -376,51 +501,40 @@ class Obstacle extends Component {
           ? segmentRadius * 1.25
           : segmentRadius * (0.85 + (1.0 - t) * 0.25);
 
-      final segRect =
-          Rect.fromCircle(center: Offset(segX, segY), radius: radius);
-
-      final bodyPaint = Paint()
-        ..shader = RadialGradient(
-          colors: [
-            const Color(0xFF86EFAC),
-            isHead ? const Color(0xFF22C55E) : const Color(0xFF16A34A),
-            const Color(0xFF052E16),
-          ],
-          center: const Alignment(-0.25, -0.35),
-        ).createShader(segRect)
-        ..style = PaintingStyle.fill;
-      canvas.drawCircle(Offset(segX, segY), radius, bodyPaint);
+      canvas.save();
+      canvas.translate(segX, segY);
+      canvas.scale(radius / 50, radius / 50);
+      canvas.drawCircle(
+        Offset.zero,
+        50,
+        isHead ? _wormHeadBodyPaint : _wormBodyPaint,
+      );
+      canvas.restore();
 
       if (!isHead) {
-        final spotPaint = Paint()
-          ..color = const Color(0xFFFACC15).withValues(alpha: 0.85);
         canvas.drawCircle(
           Offset(segX, segY - radius * 0.45),
           radius * 0.28,
-          spotPaint,
+          _wormSpotPaint,
         );
 
-        final footPaint = Paint()..color = const Color(0xFF15803D);
         canvas.drawCircle(
           Offset(segX - radius * 0.35, segY + radius * 0.9),
           radius * 0.22,
-          footPaint,
+          _wormFootPaint,
         );
         canvas.drawCircle(
           Offset(segX + radius * 0.35, segY + radius * 0.9),
           radius * 0.22,
-          footPaint,
+          _wormFootPaint,
         );
       }
 
       if (isHead) {
-        final antennaPaint = Paint()
-          ..color = const Color(0xFF15803D)
-          ..strokeWidth = 2.5 * scale
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke;
+        _wormAntennaPaint.strokeWidth = 2.5 * scale;
 
-        final leftAntenna = Path()
+        _reusableLeftAntenna
+          ..reset()
           ..moveTo(segX - radius * 0.35, segY - radius * 0.7)
           ..quadraticBezierTo(
             segX - radius * 0.8,
@@ -428,14 +542,15 @@ class Obstacle extends Component {
             segX - radius * 0.6,
             segY - radius * 1.8,
           );
-        canvas.drawPath(leftAntenna, antennaPaint);
+        canvas.drawPath(_reusableLeftAntenna, _wormAntennaPaint);
         canvas.drawCircle(
           Offset(segX - radius * 0.6, segY - radius * 1.8),
           radius * 0.22,
-          Paint()..color = const Color(0xFFFF4E50),
+          _wormAntennaTipPaint,
         );
 
-        final rightAntenna = Path()
+        _reusableRightAntenna
+          ..reset()
           ..moveTo(segX + radius * 0.35, segY - radius * 0.7)
           ..quadraticBezierTo(
             segX + radius * 0.8,
@@ -443,34 +558,30 @@ class Obstacle extends Component {
             segX + radius * 0.6,
             segY - radius * 1.8,
           );
-        canvas.drawPath(rightAntenna, antennaPaint);
+        canvas.drawPath(_reusableRightAntenna, _wormAntennaPaint);
         canvas.drawCircle(
           Offset(segX + radius * 0.6, segY - radius * 1.8),
           radius * 0.22,
-          Paint()..color = const Color(0xFFFF4E50),
+          _wormAntennaTipPaint,
         );
 
         final eyeRadius = radius * 0.32;
         final leftEyePos = Offset(segX - radius * 0.36, segY - radius * 0.15);
         final rightEyePos = Offset(segX + radius * 0.36, segY - radius * 0.15);
 
-        canvas.drawCircle(leftEyePos, eyeRadius, Paint()..color = Colors.white);
-        canvas.drawCircle(
-          rightEyePos,
-          eyeRadius,
-          Paint()..color = Colors.white,
-        );
+        canvas.drawCircle(leftEyePos, eyeRadius, _wormWhitePaint);
+        canvas.drawCircle(rightEyePos, eyeRadius, _wormWhitePaint);
 
         final pupilRadius = eyeRadius * 0.55;
         canvas.drawCircle(
           Offset(leftEyePos.dx, leftEyePos.dy + eyeRadius * 0.1),
           pupilRadius,
-          Paint()..color = Colors.black,
+          _wormBlackPaint,
         );
         canvas.drawCircle(
           Offset(rightEyePos.dx, rightEyePos.dy + eyeRadius * 0.1),
           pupilRadius,
-          Paint()..color = Colors.black,
+          _wormBlackPaint,
         );
 
         canvas.drawCircle(
@@ -479,7 +590,7 @@ class Obstacle extends Component {
             leftEyePos.dy - pupilRadius * 0.3,
           ),
           pupilRadius * 0.35,
-          Paint()..color = Colors.white,
+          _wormWhitePaint,
         );
         canvas.drawCircle(
           Offset(
@@ -487,28 +598,23 @@ class Obstacle extends Component {
             rightEyePos.dy - pupilRadius * 0.3,
           ),
           pupilRadius * 0.35,
-          Paint()..color = Colors.white,
+          _wormWhitePaint,
         );
 
-        final blushPaint = Paint()
-          ..color = const Color(0xFFFF69B4).withValues(alpha: 0.6);
         canvas.drawCircle(
           Offset(segX - radius * 0.55, segY + radius * 0.25),
           radius * 0.22,
-          blushPaint,
+          _wormBlushPaint,
         );
         canvas.drawCircle(
           Offset(segX + radius * 0.55, segY + radius * 0.25),
           radius * 0.22,
-          blushPaint,
+          _wormBlushPaint,
         );
 
-        final mouthPaint = Paint()
-          ..color = const Color(0xFF052E16)
-          ..strokeWidth = 2.0 * scale
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke;
-        final mouthPath = Path()
+        _wormMouthPaint.strokeWidth = 2.0 * scale;
+        _reusableMouth
+          ..reset()
           ..moveTo(segX - radius * 0.22, segY + radius * 0.35)
           ..quadraticBezierTo(
             segX,
@@ -516,7 +622,7 @@ class Obstacle extends Component {
             segX + radius * 0.22,
             segY + radius * 0.35,
           );
-        canvas.drawPath(mouthPath, mouthPaint);
+        canvas.drawPath(_reusableMouth, _wormMouthPaint);
       }
     }
   }
@@ -533,29 +639,28 @@ class Obstacle extends Component {
     final groundY = pos.dy;
 
     // Ground shadow
+    _shadowOuterPaint.color =
+        const Color(0xFF000000).withValues(alpha: 0.45 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: Offset(pos.dx, groundY + 4 * scale),
         width: barW * 1.1,
         height: 12 * scale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: 0.45 * scale),
+      _shadowOuterPaint,
     );
 
     // Stanchion Legs
-    final legPaint = Paint()
-      ..color = const Color(0xFF334155)
-      ..strokeWidth = 4.0 * scale
-      ..style = PaintingStyle.stroke;
+    _barricadeLegPaint.strokeWidth = 4.0 * scale;
     canvas.drawLine(
       Offset(pos.dx - barW * 0.38, groundY),
       Offset(pos.dx - barW * 0.38, groundY - barH),
-      legPaint,
+      _barricadeLegPaint,
     );
     canvas.drawLine(
       Offset(pos.dx + barW * 0.38, groundY),
       Offset(pos.dx + barW * 0.38, groundY - barH),
-      legPaint,
+      _barricadeLegPaint,
     );
 
     // Barricade Rail with Hazard Diagonal Stripes
@@ -567,20 +672,17 @@ class Obstacle extends Component {
     final railRRect =
         RRect.fromRectAndRadius(railRect, Radius.circular(4 * scale));
 
-    canvas.drawRRect(railRRect, Paint()..color = const Color(0xFFFFB300));
+    canvas.drawRRect(railRRect, _barricadeRailPaint);
 
     // Black chevron stripes
     canvas.save();
     canvas.clipRRect(railRRect);
-    final stripePaint = Paint()
-      ..color = const Color(0xFF1E293B)
-      ..strokeWidth = 8.0 * scale
-      ..style = PaintingStyle.stroke;
+    _barricadeStripePaint.strokeWidth = 8.0 * scale;
     for (double x = -barW; x <= barW * 2; x += 18 * scale) {
       canvas.drawLine(
         Offset(railRect.left + x, railRect.bottom + 5 * scale),
         Offset(railRect.left + x + 16 * scale, railRect.top - 5 * scale),
-        stripePaint,
+        _barricadeStripePaint,
       );
     }
     canvas.restore();
@@ -596,18 +698,20 @@ class Obstacle extends Component {
           Offset(pos.dx + xSign * (barW * 0.38), groundY - barH - 4 * scale);
 
       if (strobeFlash) {
+        _beaconGlowPaint.color =
+            const Color(0xFFFFD54F).withValues(alpha: 0.25 * scale);
         canvas.drawCircle(
           beaconPos,
           10 * scale,
-          Paint()
-            ..color = const Color(0xFFFFD54F).withValues(alpha: 0.25 * scale),
+          _beaconGlowPaint,
         );
       }
 
+      _beaconCorePaint.color = strobeColor;
       canvas.drawCircle(
         beaconPos,
         5 * scale,
-        Paint()..color = strobeColor,
+        _beaconCorePaint,
       );
     }
   }
@@ -619,13 +723,15 @@ class Obstacle extends Component {
     final groundY = pos.dy;
 
     // Ground shadow beneath posts
+    _shadowOuterPaint.color =
+        const Color(0xFF000000).withValues(alpha: 0.35 * scale);
     canvas.drawOval(
       Rect.fromCenter(
         center: Offset(pos.dx, groundY + 4 * scale),
         width: gateW * 1.05,
         height: 10 * scale,
       ),
-      Paint()..color = const Color(0xFF000000).withValues(alpha: 0.35 * scale),
+      _shadowOuterPaint,
     );
 
     final leftPostX = pos.dx - gateW * 0.45;
@@ -633,36 +739,29 @@ class Obstacle extends Component {
     final topY = groundY - gateH;
 
     // Cybernetic Vertical Pylons
-    final postPaint = Paint()
-      ..color = const Color(0xFF1E293B)
-      ..strokeWidth = 6.0 * scale
-      ..strokeCap = StrokeCap.round
-      ..style = PaintingStyle.stroke;
+    _gatePostPaint.strokeWidth = 6.0 * scale;
     canvas.drawLine(
       Offset(leftPostX, groundY),
       Offset(leftPostX, topY),
-      postPaint,
+      _gatePostPaint,
     );
     canvas.drawLine(
       Offset(rightPostX, groundY),
       Offset(rightPostX, topY),
-      postPaint,
+      _gatePostPaint,
     );
 
     // Cyan accent lines on pylons
-    final neonLinePaint = Paint()
-      ..color = const Color(0xFF00E5FF).withValues(alpha: 0.8)
-      ..strokeWidth = 2.0 * scale
-      ..style = PaintingStyle.stroke;
+    _gateNeonLinePaint.strokeWidth = 2.0 * scale;
     canvas.drawLine(
       Offset(leftPostX, groundY),
       Offset(leftPostX, topY),
-      neonLinePaint,
+      _gateNeonLinePaint,
     );
     canvas.drawLine(
       Offset(rightPostX, groundY),
       Offset(rightPostX, topY),
-      neonLinePaint,
+      _gateNeonLinePaint,
     );
 
     // Top Crossbar
@@ -673,13 +772,12 @@ class Obstacle extends Component {
     );
     final crossbarRRect =
         RRect.fromRectAndRadius(crossbarRect, Radius.circular(4 * scale));
-    canvas.drawRRect(crossbarRRect, Paint()..color = const Color(0xFF0F172A));
+    canvas.drawRRect(crossbarRRect, _gateCrossbarBgPaint);
+
+    _gateCrossbarBorderPaint.strokeWidth = 1.5 * scale;
     canvas.drawRRect(
       crossbarRRect,
-      Paint()
-        ..color = const Color(0xFFFFC107).withValues(alpha: 0.7)
-        ..strokeWidth = 1.5 * scale
-        ..style = PaintingStyle.stroke,
+      _gateCrossbarBorderPaint,
     );
 
     // "UNDER REVIEW" pre-cached text banner
@@ -693,42 +791,41 @@ class Obstacle extends Component {
     canvas.restore();
 
     // High Security Laser Beams (positioned from 55% to 85% height off the ground)
-    // Low slide clears cleanly below!
     final laserPulse = (sin(_wobblePhase + depth * 18) * 0.5 + 0.5);
     final laserY1 = topY + 22 * scale;
     final laserY2 = topY + 36 * scale;
+
+    _gateLaserGlowPaint
+      ..color =
+          const Color(0xFFFF1744).withValues(alpha: 0.25 * laserPulse * scale)
+      ..strokeWidth = 8.0 * scale;
+
+    _gateLaserCorePaint
+      ..color = const Color(0xFFFF5252).withValues(alpha: 0.95 * scale)
+      ..strokeWidth = 3.0 * scale;
+
+    _gateLaserFilamentPaint
+      ..color = Colors.white.withValues(alpha: 0.85 * scale)
+      ..strokeWidth = 1.2 * scale;
 
     for (final ly in [laserY1, laserY2]) {
       // Stepped soft outer glow
       canvas.drawLine(
         Offset(leftPostX, ly),
         Offset(rightPostX, ly),
-        Paint()
-          ..color = const Color(0xFFFF1744)
-              .withValues(alpha: 0.25 * laserPulse * scale)
-          ..strokeWidth = 8.0 * scale
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke,
+        _gateLaserGlowPaint,
       );
       // Bright laser core
       canvas.drawLine(
         Offset(leftPostX, ly),
         Offset(rightPostX, ly),
-        Paint()
-          ..color = const Color(0xFFFF5252).withValues(alpha: 0.95 * scale)
-          ..strokeWidth = 3.0 * scale
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke,
+        _gateLaserCorePaint,
       );
       // White hot filament
       canvas.drawLine(
         Offset(leftPostX, ly),
         Offset(rightPostX, ly),
-        Paint()
-          ..color = Colors.white.withValues(alpha: 0.85 * scale)
-          ..strokeWidth = 1.2 * scale
-          ..strokeCap = StrokeCap.round
-          ..style = PaintingStyle.stroke,
+        _gateLaserFilamentPaint,
       );
     }
   }

--- a/shorebird_runner/lib/game/components/patch.dart
+++ b/shorebird_runner/lib/game/components/patch.dart
@@ -160,17 +160,97 @@ class Patch extends Component {
     }
   }
 
+  static final Paint _shadowOuterPaint = Paint()
+    ..color = const Color(0x28000000);
+  static final Paint _shadowInnerPaint = Paint()
+    ..color = const Color(0x66000000);
+  static final Paint _magGlowOuterPaint = Paint();
+  static final Paint _magGlowInnerPaint = Paint();
+  static final Paint _fluxPaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _ambientGlowOuterPaint = Paint();
+  static final Paint _ambientGlowInnerPaint = Paint();
+  static final Paint _gyroRingPaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _badgeBorderPaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _boosterRingPaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _boltPaint = Paint()
+    ..color = const Color(0xFFFFFFFF)
+    ..style = PaintingStyle.fill;
+  static final Paint _boltBorderPaint = Paint()..style = PaintingStyle.stroke;
+
+  static const Rect _unitRect = Rect.fromLTWH(-50, -50, 100, 100);
+  static final RRect _unitRRect =
+      RRect.fromRectAndRadius(_unitRect, const Radius.circular(19));
+
+  static final Paint _frontBadgePaint = Paint()
+    ..shader = const LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [
+        Color(0xFF00F0FF),
+        Color(0xFF0088FF),
+        Color(0xFF0D1B3A),
+      ],
+      stops: [0.0, 0.5, 1.0],
+    ).createShader(_unitRect)
+    ..style = PaintingStyle.fill;
+
+  static final Paint _backBadgePaint = Paint()
+    ..shader = const LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [
+        Color(0xFF0088FF),
+        Color(0xFF0055BB),
+        Color(0xFF060D1E),
+      ],
+      stops: [0.0, 0.5, 1.0],
+    ).createShader(_unitRect)
+    ..style = PaintingStyle.fill;
+
+  static final Paint _boosterCorePaint = Paint()
+    ..shader = const LinearGradient(
+      colors: [
+        Color(0xFFFFEE00),
+        Color(0xFFFF8800),
+        Color(0xFFFF0055),
+      ],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    ).createShader(_unitRect)
+    ..style = PaintingStyle.fill;
+
+  static const Rect _beamRect = Rect.fromLTWH(-8, -90, 16, 90);
+  static final Paint _beamPaint = Paint()
+    ..shader = const LinearGradient(
+      begin: Alignment.bottomCenter,
+      end: Alignment.topCenter,
+      colors: [
+        Color(0x4D00E5FF),
+        Color(0x0000E5FF),
+      ],
+    ).createShader(_beamRect);
+
+  static final Path _reusableBoltPath = Path();
+
   void _drawShadow(Canvas canvas, Offset pos, double scale) {
     final shadowCenter = Offset(pos.dx, pos.dy + 8 * scale);
     final sw = GameConfig.patchNearSize * 0.95 * scale;
     final sh = 12 * scale;
     canvas.drawOval(
-      Rect.fromCenter(center: shadowCenter, width: sw * 1.3, height: sh * 1.3),
-      Paint()..color = const Color(0x28000000),
+      Rect.fromCenter(
+        center: shadowCenter,
+        width: sw * 1.3,
+        height: sh * 1.3,
+      ),
+      _shadowOuterPaint,
     );
     canvas.drawOval(
-      Rect.fromCenter(center: shadowCenter, width: sw, height: sh),
-      Paint()..color = const Color(0x66000000),
+      Rect.fromCenter(
+        center: shadowCenter,
+        width: sw,
+        height: sh,
+      ),
+      _shadowInnerPaint,
     );
   }
 
@@ -195,68 +275,64 @@ class Patch extends Component {
 
     // Radiant Golden/Cyan Magnetic Attraction Field
     if (isBeingMagnetized) {
+      _magGlowOuterPaint.color =
+          const Color(0xFFFFD700).withValues(alpha: 0.20 * scale);
       canvas.drawCircle(
         Offset.zero,
         size * 1.05,
-        Paint()
-          ..color = const Color(0xFFFFD700).withValues(alpha: 0.20 * scale),
+        _magGlowOuterPaint,
       );
+      _magGlowInnerPaint.color =
+          const Color(0xFFFFD700).withValues(alpha: 0.45 * scale);
       canvas.drawCircle(
         Offset.zero,
         size * 0.75,
-        Paint()
-          ..color = const Color(0xFFFFD700).withValues(alpha: 0.45 * scale),
+        _magGlowInnerPaint,
       );
 
-      final fluxPaint = Paint()
+      _fluxPaint
         ..color = const Color(0xFF00FFCC).withValues(alpha: 0.85 * scale)
-        ..strokeWidth = 1.8 * scale
-        ..style = PaintingStyle.stroke;
+        ..strokeWidth = 1.8 * scale;
       final fluxRadius = size * (0.85 + sin(_pulsePhase * 3) * 0.12);
-      canvas.drawCircle(Offset.zero, fluxRadius, fluxPaint);
+      canvas.drawCircle(Offset.zero, fluxRadius, _fluxPaint);
     }
 
-    // Vertical holographic light beam shooting into sky
-    final beamPaint = Paint()
-      ..shader = LinearGradient(
-        begin: Alignment.bottomCenter,
-        end: Alignment.topCenter,
-        colors: [
-          const Color(0xFF00E5FF).withValues(alpha: 0.30 * scale),
-          const Color(0xFF00E5FF).withValues(alpha: 0.0),
-        ],
-      ).createShader(
-        Rect.fromLTWH(-8 * scale, -90 * scale, 16 * scale, 90 * scale),
-      );
+    // Vertical holographic light beam shooting into sky (scaled via canvas)
+    canvas.save();
+    canvas.scale(scale, scale);
     canvas.drawRect(
-      Rect.fromLTWH(-8 * scale, -90 * scale, 16 * scale, 90 * scale),
-      beamPaint,
+      _beamRect,
+      _beamPaint,
     );
+    canvas.restore();
 
-    // 1. Radiant Cyan/Gold Ambient Glow (concentric circles, zero blur overhead)
+    // 1. Radiant Cyan/Gold Ambient Glow
+    _ambientGlowOuterPaint.color =
+        const Color(0xFF00D4FF).withValues(alpha: 0.16 * scale);
     canvas.drawCircle(
       Offset.zero,
       size * 0.85,
-      Paint()..color = const Color(0xFF00D4FF).withValues(alpha: 0.16 * scale),
+      _ambientGlowOuterPaint,
     );
+    _ambientGlowInnerPaint.color =
+        const Color(0xFF00D4FF).withValues(alpha: 0.38 * scale);
     canvas.drawCircle(
       Offset.zero,
       size * 0.58,
-      Paint()..color = const Color(0xFF00D4FF).withValues(alpha: 0.38 * scale),
+      _ambientGlowInnerPaint,
     );
 
     // Concentric Holographic Gyroscope Orbiting Rings
-    final ring1Paint = Paint()
+    _gyroRingPaint
       ..color = const Color(0xFF00FFCC).withValues(alpha: 0.75 * scale)
-      ..strokeWidth = 1.6 * scale
-      ..style = PaintingStyle.stroke;
+      ..strokeWidth = 1.6 * scale;
     canvas.drawOval(
       Rect.fromCenter(
         center: Offset.zero,
         width: size * 1.2 * absCos,
         height: size * 1.2,
       ),
-      ring1Paint,
+      _gyroRingPaint,
     );
 
     // 2. Futuristic Hexagonal OTA Patch Badge
@@ -264,30 +340,22 @@ class Patch extends Component {
     final badgeW = r * 1.8 * absCos;
     final badgeH = r * 1.8;
 
-    final patchRect =
-        Rect.fromCenter(center: Offset.zero, width: badgeW, height: badgeH);
-    final rrect =
-        RRect.fromRectAndRadius(patchRect, Radius.circular(r * 0.38 * absCos));
-
-    // Badge Gradient (Shorebird Cyan into Deep Indigo)
-    final bgPaint = Paint()
-      ..shader = LinearGradient(
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-        colors: isFront
-            ? const [Color(0xFF00F0FF), Color(0xFF0088FF), Color(0xFF0D1B3A)]
-            : const [Color(0xFF0088FF), Color(0xFF0055BB), Color(0xFF060D1E)],
-        stops: const [0.0, 0.5, 1.0],
-      ).createShader(patchRect)
-      ..style = PaintingStyle.fill;
-    canvas.drawRRect(rrect, bgPaint);
+    canvas.save();
+    canvas.scale(badgeW / 100, badgeH / 100);
+    canvas.drawRRect(
+      _unitRRect,
+      isFront ? _frontBadgePaint : _backBadgePaint,
+    );
 
     // Outer Crisp Neon Rim
-    final borderPaint = Paint()
+    _badgeBorderPaint
       ..color = const Color(0xFFFFD700)
-      ..strokeWidth = 2.2 * scale * absCos
-      ..style = PaintingStyle.stroke;
-    canvas.drawRRect(rrect, borderPaint);
+      ..strokeWidth = (2.2 * scale * absCos) * (100 / badgeH);
+    canvas.drawRRect(
+      _unitRRect,
+      _badgeBorderPaint,
+    );
+    canvas.restore();
 
     // 🐤 Shorebird Baby Chick Symbol in center (cached TextPainter)
     canvas.save();
@@ -318,54 +386,52 @@ class Patch extends Component {
     final absCos = cosSpin.abs().clamp(0.2, 1.0);
 
     // Radiant Gold / Crimson Energy Aura (concentric glow)
+    _magGlowOuterPaint.color =
+        const Color(0xFFFFD700).withValues(alpha: 0.22 * scale);
     canvas.drawCircle(
       Offset.zero,
       size * 0.95,
-      Paint()..color = const Color(0xFFFFD700).withValues(alpha: 0.22 * scale),
+      _magGlowOuterPaint,
     );
+    _magGlowInnerPaint.color =
+        const Color(0xFFFFD700).withValues(alpha: 0.50 * scale);
     canvas.drawCircle(
       Offset.zero,
       size * 0.65,
-      Paint()..color = const Color(0xFFFFD700).withValues(alpha: 0.50 * scale),
+      _magGlowInnerPaint,
     );
 
     // Outer rotating energy ring
-    final ringPaint = Paint()
+    _boosterRingPaint
       ..color = const Color(0xFF00FFCC).withValues(alpha: 0.7 * scale)
-      ..strokeWidth = 2.0 * scale
-      ..style = PaintingStyle.stroke;
+      ..strokeWidth = 2.0 * scale;
     canvas.drawOval(
       Rect.fromCenter(
         center: Offset.zero,
         width: size * 1.3 * absCos,
         height: size * 1.3,
       ),
-      ringPaint,
+      _boosterRingPaint,
     );
 
     // Octagonal Core
     final r = size * 0.58;
-    final coreRect = Rect.fromCenter(
-      center: Offset.zero,
-      width: r * 1.8 * absCos,
-      height: r * 1.8,
+    final coreW = r * 1.8 * absCos;
+    final coreH = r * 1.8;
+
+    canvas.save();
+    canvas.scale(coreW / 100, coreH / 100);
+    canvas.drawRRect(
+      _unitRRect,
+      _boosterCorePaint,
     );
-    final coreRRect =
-        RRect.fromRectAndRadius(coreRect, Radius.circular(r * 0.4 * absCos));
+    canvas.restore();
 
-    final corePaint = Paint()
-      ..shader = const LinearGradient(
-        colors: [Color(0xFFFFEE00), Color(0xFFFF8800), Color(0xFFFF0055)],
-        begin: Alignment.topLeft,
-        end: Alignment.bottomRight,
-      ).createShader(coreRect)
-      ..style = PaintingStyle.fill;
-    canvas.drawRRect(coreRRect, corePaint);
-
-    // ⚡ Lightning Bolt Emblem
+    // ⚡ Lightning Bolt Emblem (reusable path)
     canvas.save();
     canvas.scale(absCos, 1.0);
-    final boltPath = Path()
+    _reusableBoltPath
+      ..reset()
       ..moveTo(2 * scale, -r * 0.65)
       ..lineTo(-r * 0.45, 0)
       ..lineTo(-1 * scale, 0)
@@ -374,16 +440,12 @@ class Patch extends Component {
       ..lineTo(1 * scale, -1 * scale)
       ..close();
 
-    final boltPaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(boltPath, boltPaint);
+    canvas.drawPath(_reusableBoltPath, _boltPaint);
 
-    final boltBorder = Paint()
+    _boltBorderPaint
       ..color = const Color(0xFFFF0055)
-      ..strokeWidth = 1.5 * scale
-      ..style = PaintingStyle.stroke;
-    canvas.drawPath(boltPath, boltBorder);
+      ..strokeWidth = 1.5 * scale;
+    canvas.drawPath(_reusableBoltPath, _boltBorderPaint);
     canvas.restore();
 
     canvas.restore();
@@ -399,22 +461,5 @@ class Patch extends Component {
     for (final mp in _magnetParticles) {
       mp.render(canvas);
     }
-
-    // Reusable paint instances with ZERO allocations in hot loop
-    final glowPaint = Paint()
-      ..color = const Color(0xFFFFD700).withValues(alpha: 0.85)
-      ..strokeWidth = 2.2
-      ..style = PaintingStyle.stroke;
-    final corePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..strokeWidth = 1.0
-      ..style = PaintingStyle.stroke;
-
-    canvas.drawLine(const Offset(-14, 0), const Offset(14, 0), glowPaint);
-    canvas.drawLine(const Offset(-14, 0), const Offset(14, 0), corePaint);
-    canvas.drawLine(const Offset(0, -14), const Offset(0, 14), glowPaint);
-    canvas.drawLine(const Offset(0, -14), const Offset(0, 14), corePaint);
-
-    canvas.restore();
   }
 }

--- a/shorebird_runner/lib/game/components/patch.dart
+++ b/shorebird_runner/lib/game/components/patch.dart
@@ -25,6 +25,7 @@ class Patch extends Component {
   double _spinPhase;
   double _pulsePhase;
   int totalPatches = 0;
+  bool isInvincible = false;
   final Random _rng;
 
   final void Function(Offset pos)? onMissed;
@@ -81,7 +82,8 @@ class Patch extends Component {
   @override
   void update(double dt) {
     if (!isCollected) {
-      final speed = GameConfig.scrollSpeed(totalPatches);
+      final speed =
+          GameConfig.scrollSpeed(totalPatches, isInvincible: isInvincible);
       final forwardBoost = isBeingMagnetized ? 1.18 : 1.0;
       depth += dt * speed * 0.54 * forwardBoost;
       _spinPhase += dt * (isHotReloadBooster ? 4.8 : 3.6);

--- a/shorebird_runner/lib/game/components/patch.dart
+++ b/shorebird_runner/lib/game/components/patch.dart
@@ -93,10 +93,13 @@ class Patch extends Component {
         _magnetLean *= (1.0 - dt * 5.0).clamp(0.0, 1.0);
       }
 
-      for (final mp in _magnetParticles) {
+      for (int i = _magnetParticles.length - 1; i >= 0; i--) {
+        final mp = _magnetParticles[i];
         mp.update(dt);
+        if (mp.life <= 0) {
+          _magnetParticles.removeAt(i);
+        }
       }
-      _magnetParticles.removeWhere((mp) => mp.life <= 0);
 
       if (depth >= 1.04 && !hasTriggeredMiss) {
         hasTriggeredMiss = true;
@@ -106,8 +109,12 @@ class Patch extends Component {
       }
     } else {
       _collectAnimation = (_collectAnimation + dt * 3.5).clamp(0, 1);
-      for (final s in _sparkles) {
+      for (int i = _sparkles.length - 1; i >= 0; i--) {
+        final s = _sparkles[i];
         s.update(dt);
+        if (s.life <= 0) {
+          _sparkles.removeAt(i);
+        }
       }
     }
   }
@@ -129,10 +136,9 @@ class Patch extends Component {
     }
 
     final pos = worldPosition;
-    final rng = Random();
     final count = isHotReloadBooster ? 24 : 18;
     for (int i = 0; i < count; i++) {
-      _sparkles.add(Sparkle(pos, rng, isBooster: isHotReloadBooster));
+      _sparkles.add(Sparkle(pos, _rng, isBooster: isHotReloadBooster));
     }
   }
 

--- a/shorebird_runner/lib/game/components/patch.dart
+++ b/shorebird_runner/lib/game/components/patch.dart
@@ -32,13 +32,15 @@ class Patch extends Component {
   final List<Sparkle> _sparkles = [];
   final List<MagneticTrailParticle> _magnetParticles = [];
 
-  static final TextPainter _staticChickPainter = TextPainter(
-    text: const TextSpan(
-      text: '🐤',
-      style: TextStyle(fontSize: 24),
-    ),
-    textDirection: TextDirection.ltr,
-  )..layout();
+  // High-performance vector bird emblem paints (zero font dependencies)
+  static final Paint _birdBodyPaint = Paint()..color = const Color(0xFFFFD54F);
+  static final Paint _birdWingPaint = Paint()..color = const Color(0xFFFFB300);
+  static final Paint _birdEyePaint = Paint()..color = const Color(0xFF0F172A);
+  static final Paint _birdEyeGlint = Paint()..color = const Color(0xFFFFFFFF);
+  static final Paint _birdBeakPaint = Paint()..color = const Color(0xFFFF5722);
+  static final Paint _birdCrestPaint = Paint()..color = const Color(0xFFFFB300);
+  static final Path _beakPath = Path();
+  static final Path _crestPath = Path();
 
   Patch({
     required this.lane,
@@ -365,15 +367,50 @@ class Patch extends Component {
     );
     canvas.restore();
 
-    // 🐤 Shorebird Baby Chick Symbol in center (cached TextPainter)
+    // Vector Shorebird Emblem in center (100% font-independent, zero Noto font requests)
     canvas.save();
-    final chickScale = (badgeH * 0.58) / 24.0;
-    canvas.scale(absCos * chickScale, chickScale);
-    _staticChickPainter.paint(
-      canvas,
-      Offset(-_staticChickPainter.width / 2, -_staticChickPainter.height / 2),
-    );
+    canvas.scale(absCos, 1.0);
+    _drawVectorBird(canvas, badgeH * 0.58);
     canvas.restore();
+
+    canvas.restore();
+  }
+
+  void _drawVectorBird(Canvas canvas, double size) {
+    canvas.save();
+    final s = size / 24.0;
+    canvas.scale(s, s);
+
+    // Head/Body
+    canvas.drawCircle(const Offset(0, 0), 10.5, _birdBodyPaint);
+
+    // Crest
+    _crestPath
+      ..reset()
+      ..moveTo(0, -10.5)
+      ..quadraticBezierTo(2, -15, 6, -14)
+      ..quadraticBezierTo(2, -11, 1, -8.5)
+      ..close();
+    canvas.drawPath(_crestPath, _birdCrestPaint);
+
+    // Wing
+    canvas.drawOval(
+      Rect.fromCenter(center: const Offset(-2.5, 2.0), width: 11, height: 8),
+      _birdWingPaint,
+    );
+
+    // Beak
+    _beakPath
+      ..reset()
+      ..moveTo(8.5, -2)
+      ..lineTo(14.5, 0.5)
+      ..lineTo(8, 3.5)
+      ..close();
+    canvas.drawPath(_beakPath, _birdBeakPaint);
+
+    // Eye & Glint
+    canvas.drawCircle(const Offset(3.5, -2.5), 2.2, _birdEyePaint);
+    canvas.drawCircle(const Offset(4.2, -3.2), 0.8, _birdEyeGlint);
 
     canvas.restore();
   }

--- a/shorebird_runner/lib/game/components/player.dart
+++ b/shorebird_runner/lib/game/components/player.dart
@@ -293,8 +293,8 @@ class Player extends Component {
 
     _runPhase += dt * 14.0;
 
-    // Cyber ghosting echo trail tracking
-    if (_laneProgress < 1.0 || isInvincible) {
+    // Cyber ghosting echo trail tracking (only during Hot Reload overdrive)
+    if (isInvincible) {
       _ghostPositions.insert(0, worldPosition);
       if (_ghostPositions.length > 3) _ghostPositions.removeLast();
     } else if (_ghostPositions.isNotEmpty) {

--- a/shorebird_runner/lib/game/components/player.dart
+++ b/shorebird_runner/lib/game/components/player.dart
@@ -197,18 +197,19 @@ class Player extends Component {
     return -sin(t * pi) * 78.0;
   }
 
-  Offset get worldPosition {
-    final baseOffset = () {
-      if (_laneProgress >= 1.0) {
-        return PerspectiveHelper.lanePosition(_targetLane, 1.0);
-      }
-      final from = PerspectiveHelper.lanePosition(currentLane, 1.0);
-      final to = PerspectiveHelper.lanePosition(_targetLane, 1.0);
-      final t = Curves.easeInOutCubic.transform(_laneProgress.clamp(0, 1));
-      return Offset(from.dx + (to.dx - from.dx) * t, from.dy);
-    }();
+  Offset get groundPosition {
+    if (_laneProgress >= 1.0) {
+      return PerspectiveHelper.lanePosition(_targetLane, 1.0);
+    }
+    final from = PerspectiveHelper.lanePosition(currentLane, 1.0);
+    final to = PerspectiveHelper.lanePosition(_targetLane, 1.0);
+    final t = Curves.easeInOutCubic.transform(_laneProgress.clamp(0, 1));
+    return Offset(from.dx + (to.dx - from.dx) * t, from.dy);
+  }
 
-    return Offset(baseOffset.dx, baseOffset.dy + jumpOffsetY);
+  Offset get worldPosition {
+    final gp = groundPosition;
+    return Offset(gp.dx, gp.dy + jumpOffsetY);
   }
 
   double get rollAngle {
@@ -312,10 +313,13 @@ class Player extends Component {
       }
     }
 
-    for (final p in _particles) {
+    for (int i = _particles.length - 1; i >= 0; i--) {
+      final p = _particles[i];
       p.update(dt);
+      if (p.life <= 0) {
+        _particles.removeAt(i);
+      }
     }
-    _particles.removeWhere((p) => p.life <= 0);
   }
 
   Color _getAuraColor() {
@@ -339,16 +343,7 @@ class Player extends Component {
   }
 
   void _drawShadow(Canvas canvas) {
-    final groundPos = () {
-      if (_laneProgress >= 1.0) {
-        return PerspectiveHelper.lanePosition(_targetLane, 1.0);
-      }
-      final from = PerspectiveHelper.lanePosition(currentLane, 1.0);
-      final to = PerspectiveHelper.lanePosition(_targetLane, 1.0);
-      final t = Curves.easeInOutCubic.transform(_laneProgress.clamp(0, 1));
-      return Offset(from.dx + (to.dx - from.dx) * t, from.dy);
-    }();
-
+    final groundPos = groundPosition;
     final shadowY = groundPos.dy + 34;
     final stepBounce = sin(_runPhase * 2).abs() * 3.0;
 

--- a/shorebird_runner/lib/game/components/player.dart
+++ b/shorebird_runner/lib/game/components/player.dart
@@ -43,6 +43,94 @@ class Player extends Component {
   bool get isSliding => _isSliding;
   bool get isInvincible => _invincibleTimer > 0;
 
+  // Reusable geometry paths for zero-allocation rendering
+  final Path _leftLegPath = Path();
+  final Path _rightLegPath = Path();
+  final Path _hoodCollarPath = Path();
+  final Path _leftArmPath = Path();
+  final Path _rightArmPath = Path();
+  final Path _birdPath = Path();
+
+  // Cyber ghosting echo trail
+  final List<Offset> _ghostPositions = [];
+
+  // Reusable pooled paints
+  static final Paint _shadowOuter = Paint();
+  static final Paint _shadowMid = Paint();
+  static final Paint _shadowCore = Paint();
+  static final Paint _shockwavePaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _ghostPaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _shieldPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 3.5;
+  static final Paint _shieldAura = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 4.0;
+  static final Paint _shieldNodeGlow = Paint();
+  static final Paint _shieldNodeMid = Paint();
+  static final Paint _shieldNodeCore = Paint()..color = const Color(0xFFFFFFFF);
+  static final Paint _auraOuter = Paint();
+  static final Paint _auraInner = Paint();
+  static final Paint _legPaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _seamPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.2;
+  static final Paint _shoePaint = Paint()..color = const Color(0xFF0F172A);
+  static final Paint _solePaint = Paint()..style = PaintingStyle.stroke;
+  static final Paint _soleGlowOuter = Paint();
+  static final Paint _soleGlowInner = Paint();
+  static final Paint _hoodiePaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _hoodCollarPaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _emblemBg = Paint()
+    ..color = const Color(0xFF030712).withValues(alpha: 0.85)
+    ..style = PaintingStyle.fill;
+  static final Paint _emblemBorder = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.6;
+  static final Paint _emblemGlowOuter = Paint();
+  static final Paint _emblemGlowInner = Paint();
+  static final Paint _birdPaint = Paint()
+    ..color = const Color(0xFF00FFCC)
+    ..style = PaintingStyle.fill;
+  static final Paint _codeLinePaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.8
+    ..strokeCap = StrokeCap.round;
+  static final Paint _hairPaint = Paint()
+    ..color = const Color(0xFF1C1917)
+    ..style = PaintingStyle.fill;
+  static final Paint _hairHighlight = Paint()
+    ..color = const Color(0xFF44403C)
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 2;
+  static final Paint _bandPaint = Paint()
+    ..color = const Color(0xFF0F172A)
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 3.8
+    ..strokeCap = StrokeCap.round;
+  static final Paint _bandTrimPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.5;
+  static final Paint _cupPaint = Paint()..color = const Color(0xFF0F172A);
+  static final Paint _cupGlow = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.8;
+  static final Paint _eqPaint = Paint()..strokeWidth = 1.0;
+  static final Paint _sleevePaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _skinPaint = Paint()..color = const Color(0xFFFBBF24);
+  static final Paint _lidPaint = Paint()..color = const Color(0xFF1E293B);
+  static final Paint _stickerPaint = Paint()
+    ..color = const Color(0xFF00D4FF)
+    ..style = PaintingStyle.fill;
+  static final Paint _screenEdge = Paint()
+    ..color = const Color(0xFF00FF88)
+    ..style = PaintingStyle.stroke
+    ..strokeWidth = 1.5;
+  static final Paint _screenGlowOuter = Paint()
+    ..color = const Color(0xFF00FF88).withValues(alpha: 0.22);
+  static final Paint _screenGlowInner = Paint()
+    ..color = const Color(0xFF00FF88).withValues(alpha: 0.65);
+
   Player({
     this.currentLane = 1,
     this.skin = PlayerSkin.blueBird,
@@ -205,6 +293,14 @@ class Player extends Component {
 
     _runPhase += dt * 14.0;
 
+    // Cyber ghosting echo trail tracking
+    if (_laneProgress < 1.0 || isInvincible) {
+      _ghostPositions.insert(0, worldPosition);
+      if (_ghostPositions.length > 3) _ghostPositions.removeLast();
+    } else if (_ghostPositions.isNotEmpty) {
+      _ghostPositions.removeLast();
+    }
+
     // Spawn footstep cyber sparks on ground
     if (!_isJumping && !_isSliding) {
       final pos = worldPosition;
@@ -265,33 +361,52 @@ class Player extends Component {
 
     // Multi-ring concentric soft shadow (hardware accelerated, zero blur pass)
     final shadowCenter = Offset(groundPos.dx, shadowY);
+    _shadowOuter.color =
+        const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.25);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: 52 * shadowScale,
         height: 18 * shadowScale,
       ),
-      Paint()
-        ..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.25),
+      _shadowOuter,
     );
+    _shadowMid.color =
+        const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.55);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: 38 * shadowScale,
         height: 13 * shadowScale,
       ),
-      Paint()
-        ..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.55),
+      _shadowMid,
     );
+    _shadowCore.color =
+        const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.85);
     canvas.drawOval(
       Rect.fromCenter(
         center: shadowCenter,
         width: 22 * shadowScale,
         height: 7 * shadowScale,
       ),
-      Paint()
-        ..color = const Color(0xFF000000).withValues(alpha: shadowAlpha * 0.85),
+      _shadowCore,
     );
+
+    // Jump Landing Impact Shockwave ring on the tarmac
+    if (_landingSquish > 0) {
+      final ringRadius = 52.0 * (1.0 + (1.0 - _landingSquish) * 0.85);
+      _shockwavePaint
+        ..color = _getAuraColor().withValues(alpha: _landingSquish * 0.65)
+        ..strokeWidth = 2.4 * _landingSquish;
+      canvas.drawOval(
+        Rect.fromCenter(
+          center: shadowCenter,
+          width: ringRadius * 1.6,
+          height: ringRadius * 0.5,
+        ),
+        _shockwavePaint,
+      );
+    }
   }
 
   void _drawParticles(Canvas canvas) {
@@ -309,6 +424,20 @@ class Player extends Component {
     final center = Offset(pos.dx, pos.dy - stepBounce);
     final roll = rollAngle;
     final size = GameConfig.playerNearSize; // responsive near size
+
+    // Cyber Ghosting Echo Trail during lane changes or Hot Reload
+    if (_ghostPositions.isNotEmpty) {
+      final ghostColor = _getAuraColor();
+      for (int i = 0; i < _ghostPositions.length; i++) {
+        final ghostAlpha = (0.24 - i * 0.08).clamp(0.04, 0.25);
+        _ghostPaint.color = ghostColor.withValues(alpha: ghostAlpha);
+        final gp = _ghostPositions[i];
+        canvas.save();
+        canvas.translate(gp.dx, gp.dy - stepBounce);
+        canvas.drawCircle(Offset.zero, size * 0.40, _ghostPaint);
+        canvas.restore();
+      }
+    }
 
     canvas.save();
     canvas.translate(center.dx, center.dy);
@@ -338,31 +467,22 @@ class Player extends Component {
     // Hot Reload invincibility energy shield
     if (isInvincible) {
       final shieldRadius = size * 0.88;
-      final shieldPaint = Paint()
-        ..shader = SweepGradient(
-          colors: const [
-            Color(0xFFFFD700),
-            Color(0xFF00FFCC),
-            Color(0xFFFF007F),
-            Color(0xFFFFD700),
-          ],
-          transform: GradientRotation(_runPhase * 4),
-        ).createShader(
-          Rect.fromCircle(center: Offset.zero, radius: shieldRadius),
-        )
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 3.5;
-      canvas.drawCircle(const Offset(0, 2), shieldRadius, shieldPaint);
+      _shieldPaint.shader = SweepGradient(
+        colors: const [
+          Color(0xFFFFD700),
+          Color(0xFF00FFCC),
+          Color(0xFFFF007F),
+          Color(0xFFFFD700),
+        ],
+        transform: GradientRotation(_runPhase * 4),
+      ).createShader(
+        Rect.fromCircle(center: Offset.zero, radius: shieldRadius),
+      );
+      canvas.drawCircle(const Offset(0, 2), shieldRadius, _shieldPaint);
 
       // Outer aura ring
-      canvas.drawCircle(
-        const Offset(0, 2),
-        shieldRadius + 4,
-        Paint()
-          ..color = const Color(0xFFFFD700).withValues(alpha: 0.25)
-          ..style = PaintingStyle.stroke
-          ..strokeWidth = 4.0,
-      );
+      _shieldAura.color = const Color(0xFFFFD700).withValues(alpha: 0.25);
+      canvas.drawCircle(const Offset(0, 2), shieldRadius + 4, _shieldAura);
 
       // Orbiting Hexagonal Shield Nodes
       const nodeCount = 5;
@@ -370,37 +490,23 @@ class Player extends Component {
         final nodeAngle = _runPhase * 3.5 + (i * 2 * pi / nodeCount);
         final nx = cos(nodeAngle) * (shieldRadius * 1.05);
         final ny = sin(nodeAngle) * (shieldRadius * 0.75) + 2;
-        canvas.drawCircle(
-          Offset(nx, ny),
-          5.5,
-          Paint()..color = const Color(0xFF00FFCC).withValues(alpha: 0.35),
-        );
-        canvas.drawCircle(
-          Offset(nx, ny),
-          3.0,
-          Paint()..color = const Color(0xFF00FFCC),
-        );
-        canvas.drawCircle(
-          Offset(nx, ny),
-          1.5,
-          Paint()..color = const Color(0xFFFFFFFF),
-        );
+        final nodePos = Offset(nx, ny);
+
+        _shieldNodeGlow.color = const Color(0xFF00FFCC).withValues(alpha: 0.35);
+        canvas.drawCircle(nodePos, 5.5, _shieldNodeGlow);
+        _shieldNodeMid.color = const Color(0xFF00FFCC);
+        canvas.drawCircle(nodePos, 3.0, _shieldNodeMid);
+        canvas.drawCircle(nodePos, 1.5, _shieldNodeCore);
       }
     }
 
     // Developer neon aura (concentric circles, zero blur overhead)
     final aura = _getAuraColor();
     final auraAlpha = isInvincible ? 0.35 : 0.16;
-    canvas.drawCircle(
-      const Offset(0, 4),
-      size * 0.90,
-      Paint()..color = aura.withValues(alpha: auraAlpha * 0.4),
-    );
-    canvas.drawCircle(
-      const Offset(0, 4),
-      size * 0.65,
-      Paint()..color = aura.withValues(alpha: auraAlpha),
-    );
+    _auraOuter.color = aura.withValues(alpha: auraAlpha * 0.4);
+    canvas.drawCircle(const Offset(0, 4), size * 0.90, _auraOuter);
+    _auraInner.color = aura.withValues(alpha: auraAlpha);
+    canvas.drawCircle(const Offset(0, 4), size * 0.65, _auraInner);
 
     _drawLegs(canvas, size);
     _drawTorso(canvas, size);
@@ -421,7 +527,8 @@ class Player extends Component {
     final leftFootSwing = stride * legLength;
     final rightFootSwing = -stride * legLength;
 
-    final leftLegPath = Path()
+    _leftLegPath
+      ..reset()
       ..moveTo(-r * 0.22, hipY)
       ..lineTo(-r * 0.26, hipY + legLength * 0.55 + leftFootSwing * 0.2)
       ..lineTo(-r * 0.24, hipY + legLength + leftFootSwing)
@@ -430,7 +537,8 @@ class Player extends Component {
       ..lineTo(-r * 0.10, hipY)
       ..close();
 
-    final rightLegPath = Path()
+    _rightLegPath
+      ..reset()
       ..moveTo(r * 0.10, hipY)
       ..lineTo(r * 0.14, hipY + legLength * 0.55 + rightFootSwing * 0.2)
       ..lineTo(r * 0.12, hipY + legLength + rightFootSwing)
@@ -439,18 +547,13 @@ class Player extends Component {
       ..lineTo(r * 0.22, hipY)
       ..close();
 
-    final legPaint = Paint()
-      ..color = colors[1]
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(leftLegPath, legPaint);
-    canvas.drawPath(rightLegPath, legPaint);
+    _legPaint.color = colors[1];
+    canvas.drawPath(_leftLegPath, _legPaint);
+    canvas.drawPath(_rightLegPath, _legPaint);
 
-    final seamPaint = Paint()
-      ..color = colors[2]
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.2;
-    canvas.drawPath(leftLegPath, seamPaint);
-    canvas.drawPath(rightLegPath, seamPaint);
+    _seamPaint.color = colors[2];
+    canvas.drawPath(_leftLegPath, _seamPaint);
+    canvas.drawPath(_rightLegPath, _seamPaint);
 
     _drawRunningShoe(
       canvas,
@@ -475,7 +578,6 @@ class Player extends Component {
     canvas.save();
     canvas.translate(pos.dx, pos.dy);
 
-    final shoePaint = Paint()..color = const Color(0xFF0F172A);
     final shoeRect = RRect.fromRectAndRadius(
       Rect.fromCenter(
         center: const Offset(0, 0),
@@ -484,30 +586,23 @@ class Player extends Component {
       ),
       Radius.circular(2 * scale),
     );
-    canvas.drawRRect(shoeRect, shoePaint);
+    canvas.drawRRect(shoeRect, _shoePaint);
 
     final soleColor = _getAuraColor();
-    final solePaint = Paint()
+    _solePaint
       ..color = soleColor
-      ..style = PaintingStyle.stroke
       ..strokeWidth = 2.0 * scale;
     canvas.drawLine(
       Offset(-6 * scale, 2.5 * scale),
       Offset(6 * scale, 2.5 * scale),
-      solePaint,
+      _solePaint,
     );
 
     // Sole neon glow flare (concentric)
-    canvas.drawCircle(
-      const Offset(0, 3.5),
-      7,
-      Paint()..color = soleColor.withValues(alpha: 0.22),
-    );
-    canvas.drawCircle(
-      const Offset(0, 3.5),
-      4,
-      Paint()..color = soleColor.withValues(alpha: 0.75),
-    );
+    _soleGlowOuter.color = soleColor.withValues(alpha: 0.22);
+    canvas.drawCircle(const Offset(0, 3.5), 7, _soleGlowOuter);
+    _soleGlowInner.color = soleColor.withValues(alpha: 0.75);
+    canvas.drawCircle(const Offset(0, 3.5), 4, _soleGlowInner);
 
     canvas.restore();
   }
@@ -532,25 +627,22 @@ class Player extends Component {
     final hoodieRRect =
         RRect.fromRectAndRadius(hoodieRect, Radius.circular(r * 0.22));
 
-    final hoodiePaint = Paint()
-      ..shader = LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [colors[0], colors[1], colors[2]],
-        stops: const [0.0, 0.5, 1.0],
-      ).createShader(hoodieRect)
-      ..style = PaintingStyle.fill;
-    canvas.drawRRect(hoodieRRect, hoodiePaint);
+    _hoodiePaint.shader = LinearGradient(
+      begin: Alignment.topCenter,
+      end: Alignment.bottomCenter,
+      colors: [colors[0], colors[1], colors[2]],
+      stops: const [0.0, 0.5, 1.0],
+    ).createShader(hoodieRect);
+    canvas.drawRRect(hoodieRRect, _hoodiePaint);
 
-    final hoodCollarPath = Path()
+    _hoodCollarPath
+      ..reset()
       ..moveTo(-r * 0.32, -r * 0.40)
       ..quadraticBezierTo(0, -r * 0.22, r * 0.32, -r * 0.40)
       ..quadraticBezierTo(0, -r * 0.30, -r * 0.32, -r * 0.40)
       ..close();
-    final hoodCollarPaint = Paint()
-      ..color = colors[2]
-      ..style = PaintingStyle.fill;
-    canvas.drawPath(hoodCollarPath, hoodCollarPaint);
+    _hoodCollarPaint.color = colors[2];
+    canvas.drawPath(_hoodCollarPath, _hoodCollarPaint);
 
     _drawDeveloperEmblem(canvas, r);
   }
@@ -559,31 +651,20 @@ class Player extends Component {
     final emblemCenter = Offset(0, -r * 0.04);
     final aura = _getAuraColor();
 
-    final badgePaint = Paint()
-      ..color = const Color(0xFF030712).withValues(alpha: 0.85)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(emblemCenter, r * 0.24, badgePaint);
+    canvas.drawCircle(emblemCenter, r * 0.24, _emblemBg);
 
-    final borderPaint = Paint()
-      ..color = aura
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.6;
-    canvas.drawCircle(emblemCenter, r * 0.24, borderPaint);
+    _emblemBorder.color = aura;
+    canvas.drawCircle(emblemCenter, r * 0.24, _emblemBorder);
 
     // Multi-ring concentric glow behind emblem
-    canvas.drawCircle(
-      emblemCenter,
-      r * 0.32,
-      Paint()..color = aura.withValues(alpha: 0.18),
-    );
-    canvas.drawCircle(
-      emblemCenter,
-      r * 0.26,
-      Paint()..color = aura.withValues(alpha: 0.38),
-    );
+    _emblemGlowOuter.color = aura.withValues(alpha: 0.18);
+    canvas.drawCircle(emblemCenter, r * 0.32, _emblemGlowOuter);
+    _emblemGlowInner.color = aura.withValues(alpha: 0.38);
+    canvas.drawCircle(emblemCenter, r * 0.26, _emblemGlowInner);
 
     if (skin == PlayerSkin.blueBird) {
-      final birdPath = Path()
+      _birdPath
+        ..reset()
         ..moveTo(emblemCenter.dx - 4, emblemCenter.dy + 3)
         ..cubicTo(
           emblemCenter.dx - 6,
@@ -603,43 +684,33 @@ class Player extends Component {
           emblemCenter.dx - 4,
           emblemCenter.dy + 3,
         );
-      final birdPaint = Paint()
-        ..color = const Color(0xFF00FFCC)
-        ..style = PaintingStyle.fill;
-      canvas.drawPath(birdPath, birdPaint);
+      canvas.drawPath(_birdPath, _birdPaint);
     } else {
-      final codePaint = Paint()
-        ..color = aura
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 1.8
-        ..strokeCap = StrokeCap.round;
-
+      _codeLinePaint.color = aura;
       canvas.drawLine(
         Offset(emblemCenter.dx - 5, emblemCenter.dy - 3),
         Offset(emblemCenter.dx - 8, emblemCenter.dy),
-        codePaint,
+        _codeLinePaint,
       );
       canvas.drawLine(
         Offset(emblemCenter.dx - 8, emblemCenter.dy),
         Offset(emblemCenter.dx - 5, emblemCenter.dy + 3),
-        codePaint,
+        _codeLinePaint,
       );
-
       canvas.drawLine(
         Offset(emblemCenter.dx - 1, emblemCenter.dy + 4),
         Offset(emblemCenter.dx + 1, emblemCenter.dy - 4),
-        codePaint,
+        _codeLinePaint,
       );
-
       canvas.drawLine(
         Offset(emblemCenter.dx + 5, emblemCenter.dy - 3),
         Offset(emblemCenter.dx + 8, emblemCenter.dy),
-        codePaint,
+        _codeLinePaint,
       );
       canvas.drawLine(
         Offset(emblemCenter.dx + 8, emblemCenter.dy),
         Offset(emblemCenter.dx + 5, emblemCenter.dy + 3),
-        codePaint,
+        _codeLinePaint,
       );
     }
   }
@@ -678,48 +749,33 @@ class Player extends Component {
     final headCenter = Offset(0, -r * 0.58);
     final headRadius = r * 0.28;
 
-    final hairPaint = Paint()
-      ..color = const Color(0xFF1C1917)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(headCenter, headRadius, hairPaint);
+    canvas.drawCircle(headCenter, headRadius, _hairPaint);
 
-    final hairHighlight = Paint()
-      ..color = const Color(0xFF44403C)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
     canvas.drawArc(
       Rect.fromCircle(center: headCenter, radius: headRadius - 1.5),
       pi * 1.1,
       pi * 0.8,
       false,
-      hairHighlight,
+      _hairHighlight,
     );
 
     final aura = _getAuraColor();
 
-    final bandPaint = Paint()
-      ..color = const Color(0xFF0F172A)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 3.8
-      ..strokeCap = StrokeCap.round;
     canvas.drawArc(
       Rect.fromCircle(center: headCenter, radius: headRadius + 2.0),
       pi * 1.12,
       pi * 0.76,
       false,
-      bandPaint,
+      _bandPaint,
     );
 
-    final bandTrimPaint = Paint()
-      ..color = aura
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.5;
+    _bandTrimPaint.color = aura;
     canvas.drawArc(
       Rect.fromCircle(center: headCenter, radius: headRadius + 2.0),
       pi * 1.18,
       pi * 0.64,
       false,
-      bandTrimPaint,
+      _bandTrimPaint,
     );
 
     final leftCupRect = RRect.fromRectAndRadius(
@@ -730,14 +786,10 @@ class Player extends Component {
       ),
       const Radius.circular(3),
     );
-    final cupPaint = Paint()..color = const Color(0xFF0F172A);
-    canvas.drawRRect(leftCupRect, cupPaint);
+    canvas.drawRRect(leftCupRect, _cupPaint);
 
-    final cupGlow = Paint()
-      ..color = aura
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.8;
-    canvas.drawRRect(leftCupRect, cupGlow);
+    _cupGlow.color = aura;
+    canvas.drawRRect(leftCupRect, _cupGlow);
 
     _drawCupEqualizer(
       canvas,
@@ -753,25 +805,23 @@ class Player extends Component {
       ),
       const Radius.circular(3),
     );
-    canvas.drawRRect(rightCupRect, cupPaint);
-    canvas.drawRRect(rightCupRect, cupGlow);
+    canvas.drawRRect(rightCupRect, _cupPaint);
+    canvas.drawRRect(rightCupRect, _cupGlow);
   }
 
   void _drawCupEqualizer(Canvas canvas, Offset center, Color color) {
-    final eqPaint = Paint()
-      ..color = color
-      ..strokeWidth = 1.0;
+    _eqPaint.color = color;
     final h1 = (sin(_runPhase * 3) * 3).abs() + 2;
     final h2 = (cos(_runPhase * 2.5) * 4).abs() + 2;
     canvas.drawLine(
       Offset(center.dx - 1.5, center.dy - h1),
       Offset(center.dx - 1.5, center.dy + h1),
-      eqPaint,
+      _eqPaint,
     );
     canvas.drawLine(
       Offset(center.dx + 1.5, center.dy - h2),
       Offset(center.dx + 1.5, center.dy + h2),
-      eqPaint,
+      _eqPaint,
     );
   }
 
@@ -780,39 +830,37 @@ class Player extends Component {
     final stride = sin(_runPhase);
     final colors = _getHoodieColors();
 
-    final sleevePaint = Paint()
-      ..color = colors.first
-      ..style = PaintingStyle.fill;
-
-    final skinPaint = Paint()..color = const Color(0xFFFBBF24);
+    _sleevePaint.color = colors.first;
 
     final leftArmSwing = -stride * r * 0.22;
     final leftShoulder = Offset(-r * 0.50, -r * 0.28);
     final leftHand = Offset(-r * 0.62, r * 0.05 + leftArmSwing);
 
-    final leftArmPath = Path()
+    _leftArmPath
+      ..reset()
       ..moveTo(leftShoulder.dx, leftShoulder.dy)
       ..lineTo(leftShoulder.dx - 8, leftShoulder.dy + 6)
       ..lineTo(leftHand.dx, leftHand.dy)
       ..lineTo(leftHand.dx + 7, leftHand.dy + 2)
       ..lineTo(leftShoulder.dx + 4, leftShoulder.dy + 12)
       ..close();
-    canvas.drawPath(leftArmPath, sleevePaint);
-    canvas.drawCircle(leftHand, 4.0, skinPaint);
+    canvas.drawPath(_leftArmPath, _sleevePaint);
+    canvas.drawCircle(leftHand, 4.0, _skinPaint);
 
     final rightArmSwing = stride * r * 0.12;
     final rightShoulder = Offset(r * 0.50, -r * 0.28);
     final rightHand = Offset(r * 0.52, r * 0.02 + rightArmSwing);
 
-    final rightArmPath = Path()
+    _rightArmPath
+      ..reset()
       ..moveTo(rightShoulder.dx, rightShoulder.dy)
       ..lineTo(rightShoulder.dx + 8, rightShoulder.dy + 6)
       ..lineTo(rightHand.dx + 6, rightHand.dy)
       ..lineTo(rightHand.dx - 2, rightHand.dy + 6)
       ..lineTo(rightShoulder.dx - 4, rightShoulder.dy + 12)
       ..close();
-    canvas.drawPath(rightArmPath, sleevePaint);
-    canvas.drawCircle(rightHand, 4.0, skinPaint);
+    canvas.drawPath(_rightArmPath, _sleevePaint);
+    canvas.drawCircle(rightHand, 4.0, _skinPaint);
 
     _drawLaptop(canvas, Offset(rightHand.dx + 8, rightHand.dy - 6));
   }
@@ -826,27 +874,14 @@ class Player extends Component {
       const Rect.fromLTWH(-8, -12, 16, 12),
       const Radius.circular(2),
     );
-    final lidPaint = Paint()..color = const Color(0xFF1E293B);
-    canvas.drawRRect(lidRect, lidPaint);
+    canvas.drawRRect(lidRect, _lidPaint);
 
-    final stickerPaint = Paint()
-      ..color = const Color(0xFF00D4FF)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(const Offset(0, -6), 2.5, stickerPaint);
-
-    final screenEdge = Paint()
-      ..color = const Color(0xFF00FF88)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.5;
-    canvas.drawLine(const Offset(-7, 0), const Offset(7, 0), screenEdge);
+    canvas.drawCircle(const Offset(0, -6), 2.5, _stickerPaint);
+    canvas.drawLine(const Offset(-7, 0), const Offset(7, 0), _screenEdge);
 
     // Concentric screen glow (no blur)
-    final screenGlowOuter = Paint()
-      ..color = const Color(0xFF00FF88).withValues(alpha: 0.22);
-    canvas.drawCircle(const Offset(0, 0), 7, screenGlowOuter);
-    final screenGlowInner = Paint()
-      ..color = const Color(0xFF00FF88).withValues(alpha: 0.65);
-    canvas.drawCircle(const Offset(0, 0), 3.5, screenGlowInner);
+    canvas.drawCircle(const Offset(0, 0), 7, _screenGlowOuter);
+    canvas.drawCircle(const Offset(0, 0), 3.5, _screenGlowInner);
 
     canvas.restore();
   }

--- a/shorebird_runner/lib/game/components/shooting_star.dart
+++ b/shorebird_runner/lib/game/components/shooting_star.dart
@@ -43,16 +43,18 @@ class ShootingStar {
       current.dy - dir.dy * length * life,
     );
 
-    _paint.shader = LinearGradient(
-      colors: [
-        const Color(0xFFFFFFFF).withValues(alpha: life),
-        const Color(0xFF00D4FF).withValues(alpha: life * 0.6),
-        const Color(0x00000000),
-      ],
-    ).createShader(Rect.fromPoints(current, tail));
-
+    // Cyan outer glow streak
+    _paint
+      ..color = const Color(0xFF00D4FF).withValues(alpha: life * 0.6)
+      ..strokeWidth = 2.4;
     canvas.drawLine(current, tail, _paint);
-    _headPaint.color = const Color(0xFFFFFFFF).withValues(alpha: life);
+
+    // White core streak
+    _headPaint
+      ..color = const Color(0xFFFFFFFF).withValues(alpha: life)
+      ..strokeWidth = 1.2
+      ..strokeCap = StrokeCap.round;
+    canvas.drawLine(current, tail, _headPaint);
     canvas.drawCircle(current, 2.2 * life, _headPaint);
   }
 }

--- a/shorebird_runner/lib/game/components/sparkle.dart
+++ b/shorebird_runner/lib/game/components/sparkle.dart
@@ -30,16 +30,15 @@ class Sparkle {
     life = (life - dt * 2.8).clamp(0.0, 1.0);
   }
 
+  static final Paint _outerPaint = Paint()..style = PaintingStyle.fill;
+  static final Paint _innerPaint = Paint()..style = PaintingStyle.fill;
+
   void render(Canvas canvas) {
     if (life <= 0) return;
-    final outerPaint = Paint()
-      ..color = color.withValues(alpha: life * 0.35)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(pos, radius * life * 1.8, outerPaint);
+    _outerPaint.color = color.withValues(alpha: life * 0.35);
+    canvas.drawCircle(pos, radius * life * 1.8, _outerPaint);
 
-    final innerPaint = Paint()
-      ..color = color.withValues(alpha: life * 0.90)
-      ..style = PaintingStyle.fill;
-    canvas.drawCircle(pos, radius * life, innerPaint);
+    _innerPaint.color = color.withValues(alpha: life * 0.90);
+    canvas.drawCircle(pos, radius * life, _innerPaint);
   }
 }

--- a/shorebird_runner/lib/game/components/speed_warp_fx.dart
+++ b/shorebird_runner/lib/game/components/speed_warp_fx.dart
@@ -1,0 +1,130 @@
+import 'dart:math';
+import 'package:flame/components.dart';
+import 'package:flutter/painting.dart';
+import 'package:shorebird_runner/game/components/perspective_helper.dart';
+
+/// High-speed hyperdrive warp streaks and dynamic electric speed lines.
+/// Zero-allocation rendering with pooled static Paint objects.
+/// Activates dynamically as speed escalates or during Hot Reload booster phases.
+class SpeedWarpFx extends Component {
+  static const int _maxLines = 14;
+  final List<_WarpStreak> _streaks = [];
+  final Random _rng = Random(77);
+
+  static final Paint _streakPaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeCap = StrokeCap.round;
+
+  static final Paint _corePaint = Paint()
+    ..style = PaintingStyle.stroke
+    ..strokeCap = StrokeCap.round
+    ..color = const Color(0xFFFFFFFF);
+
+  bool isHotReload = false;
+  double speedMultiplier = 1.0;
+
+  @override
+  Future<void> onLoad() async {
+    for (int i = 0; i < _maxLines; i++) {
+      _streaks.add(_WarpStreak.random(_rng));
+    }
+  }
+
+  @override
+  void update(double dt) {
+    final intensity =
+        (isHotReload ? 2.2 : (speedMultiplier - 0.95) * 1.5).clamp(0.0, 2.5);
+
+    if (intensity <= 0.05) return;
+
+    for (int i = 0; i < _streaks.length; i++) {
+      _streaks[i].update(dt * intensity, _rng);
+    }
+  }
+
+  @override
+  void render(Canvas canvas) {
+    final intensity =
+        (isHotReload ? 2.2 : (speedMultiplier - 0.95) * 1.5).clamp(0.0, 2.5);
+
+    if (intensity <= 0.05) return;
+
+    final alpha = (intensity * 0.45).clamp(0.0, 0.85);
+
+    for (int i = 0; i < _streaks.length; i++) {
+      final s = _streaks[i];
+      if (s.depth < 0.08 || s.depth > 1.05) continue;
+
+      final p1 = PerspectiveHelper.fractionalLanePosition(s.laneFrac, s.depth);
+      final tailDepth = (s.depth - s.length).clamp(0.02, 1.0);
+      final p0 =
+          PerspectiveHelper.fractionalLanePosition(s.laneFrac, tailDepth);
+
+      final strokeW = (1.5 + s.depth * 3.5).clamp(1.0, 5.0);
+      final lineAlpha =
+          (alpha * s.alphaScale * (s.depth * 1.2)).clamp(0.0, 0.95);
+
+      final streakColor = isHotReload
+          ? (s.isGold ? const Color(0xFFFFD700) : const Color(0xFFFF007F))
+          : const Color(0xFF00E5FF);
+
+      _streakPaint
+        ..color = streakColor.withValues(alpha: lineAlpha * 0.5)
+        ..strokeWidth = strokeW * 1.8;
+      canvas.drawLine(p0, p1, _streakPaint);
+
+      _corePaint
+        ..color = const Color(0xFFFFFFFF).withValues(alpha: lineAlpha)
+        ..strokeWidth = strokeW * 0.7;
+      canvas.drawLine(p0, p1, _corePaint);
+    }
+  }
+}
+
+class _WarpStreak {
+  double laneFrac;
+  double depth;
+  double length;
+  double speed;
+  double alphaScale;
+  bool isGold;
+
+  _WarpStreak({
+    required this.laneFrac,
+    required this.depth,
+    required this.length,
+    required this.speed,
+    required this.alphaScale,
+    required this.isGold,
+  });
+
+  factory _WarpStreak.random(Random rng) {
+    final isLeft = rng.nextBool();
+    final laneFrac = isLeft
+        ? -0.35 - rng.nextDouble() * 0.45
+        : 2.35 + rng.nextDouble() * 0.45;
+
+    return _WarpStreak(
+      laneFrac: laneFrac,
+      depth: rng.nextDouble(),
+      length: 0.08 + rng.nextDouble() * 0.12,
+      speed: 1.2 + rng.nextDouble() * 1.8,
+      alphaScale: 0.6 + rng.nextDouble() * 0.4,
+      isGold: rng.nextBool(),
+    );
+  }
+
+  void update(double step, Random rng) {
+    depth += step * speed;
+    if (depth > 1.1) {
+      depth = 0.02;
+      final isLeft = rng.nextBool();
+      laneFrac = isLeft
+          ? -0.35 - rng.nextDouble() * 0.45
+          : 2.35 + rng.nextDouble() * 0.45;
+      length = 0.08 + rng.nextDouble() * 0.12;
+      speed = 1.2 + rng.nextDouble() * 1.8;
+      isGold = rng.nextBool();
+    }
+  }
+}

--- a/shorebird_runner/lib/game/components/star.dart
+++ b/shorebird_runner/lib/game/components/star.dart
@@ -16,6 +16,8 @@ class Star {
   static final Paint _sharedStarPaint = Paint()..style = PaintingStyle.fill;
   static final Paint _sharedSpikePaint = Paint()..strokeWidth = 0.9;
 
+  final Offset pos;
+
   Star({
     required this.x,
     required this.y,
@@ -26,7 +28,8 @@ class Star {
     required this.hasCrossGlint,
     required this.tint,
     required double twinklePhase,
-  }) : _twinklePhase = twinklePhase;
+  })  : pos = Offset(x, y),
+        _twinklePhase = twinklePhase;
 
   factory Star.random(Random rng) {
     final isSpecial = rng.nextDouble() < 0.12;
@@ -62,19 +65,19 @@ class Star {
         (alpha * (0.55 + 0.45 * sin(_twinklePhase))).clamp(0.0, 1.0);
     _sharedStarPaint.color = tint.withValues(alpha: currentAlpha);
 
-    canvas.drawCircle(Offset(x, y), size, _sharedStarPaint);
+    canvas.drawCircle(pos, size, _sharedStarPaint);
 
     if (hasCrossGlint && currentAlpha > 0.65) {
       final spikeLen = size * 2.8 * currentAlpha;
       _sharedSpikePaint.color = tint.withValues(alpha: currentAlpha * 0.5);
       canvas.drawLine(
-        Offset(x - spikeLen, y),
-        Offset(x + spikeLen, y),
+        Offset(pos.dx - spikeLen, pos.dy),
+        Offset(pos.dx + spikeLen, pos.dy),
         _sharedSpikePaint,
       );
       canvas.drawLine(
-        Offset(x, y - spikeLen),
-        Offset(x, y + spikeLen),
+        Offset(pos.dx, pos.dy - spikeLen),
+        Offset(pos.dx, pos.dy + spikeLen),
         _sharedSpikePaint,
       );
     }

--- a/shorebird_runner/lib/game/components/starfield.dart
+++ b/shorebird_runner/lib/game/components/starfield.dart
@@ -45,6 +45,29 @@ class Starfield extends Component {
         ],
         stops: [0.0, 0.35, 0.65, 0.88, 1.0],
       ).createShader(Rect.fromLTWH(0, 0, w, h));
+
+    // Pre-cache nebula radial shaders centered at Offset.zero so render requires 0 allocations
+    _cyanNebulaPaint.shader = RadialGradient(
+      colors: [
+        const Color(0xFF00D4FF).withValues(alpha: 0.12),
+        const Color(0xFF0055AA).withValues(alpha: 0.05),
+        const Color(0x00000000),
+      ],
+      radius: 0.85,
+    ).createShader(
+      Rect.fromCircle(center: Offset.zero, radius: 180),
+    );
+
+    _purpleNebulaPaint.shader = RadialGradient(
+      colors: [
+        const Color(0xFF9333EA).withValues(alpha: 0.14),
+        const Color(0xFFEC4899).withValues(alpha: 0.04),
+        const Color(0x00000000),
+      ],
+      radius: 0.85,
+    ).createShader(
+      Rect.fromCircle(center: Offset.zero, radius: 200),
+    );
   }
 
   void _repopulateStars() {
@@ -77,9 +100,13 @@ class Starfield extends Component {
       }
     }
 
-    for (final ss in List.of(_shootingStars)) {
+    // Zero-allocation backwards loop for shooting stars
+    for (int i = _shootingStars.length - 1; i >= 0; i--) {
+      final ss = _shootingStars[i];
       ss.update(dt);
-      if (ss.isDead) _shootingStars.remove(ss);
+      if (ss.isDead) {
+        _shootingStars.removeAt(i);
+      }
     }
   }
 
@@ -109,37 +136,16 @@ class Starfield extends Component {
     final sin1 = sin(_nebulaPhase) * 20;
     final sin2 = cos(_nebulaPhase * 0.8) * 25;
 
-    // Cyan cosmic dust cloud (left)
-    _cyanNebulaPaint.shader = RadialGradient(
-      colors: [
-        const Color(0xFF00D4FF).withValues(alpha: 0.12),
-        const Color(0xFF0055AA).withValues(alpha: 0.05),
-        const Color(0x00000000),
-      ],
-      radius: 0.85,
-    ).createShader(
-      Rect.fromCircle(
-        center: Offset(w * 0.25 + sin1, h * 0.45),
-        radius: 180,
-      ),
-    );
-    canvas.drawCircle(Offset(w * 0.25 + sin1, h * 0.45), 180, _cyanNebulaPaint);
+    // Cyan cosmic dust cloud (left) - translated with zero allocations
+    canvas.save();
+    canvas.translate(w * 0.25 + sin1, h * 0.45);
+    canvas.drawCircle(Offset.zero, 180, _cyanNebulaPaint);
+    canvas.restore();
 
-    // Violet/Magenta cosmic dust cloud (right)
-    _purpleNebulaPaint.shader = RadialGradient(
-      colors: [
-        const Color(0xFF9333EA).withValues(alpha: 0.14),
-        const Color(0xFFEC4899).withValues(alpha: 0.04),
-        const Color(0x00000000),
-      ],
-      radius: 0.85,
-    ).createShader(
-      Rect.fromCircle(center: Offset(w * 0.75 + sin2, h * 0.4), radius: 200),
-    );
-    canvas.drawCircle(
-      Offset(w * 0.75 + sin2, h * 0.4),
-      200,
-      _purpleNebulaPaint,
-    );
+    // Violet/Magenta cosmic dust cloud (right) - translated with zero allocations
+    canvas.save();
+    canvas.translate(w * 0.75 + sin2, h * 0.4);
+    canvas.drawCircle(Offset.zero, 200, _purpleNebulaPaint);
+    canvas.restore();
   }
 }

--- a/shorebird_runner/lib/game/floating_text.dart
+++ b/shorebird_runner/lib/game/floating_text.dart
@@ -1,65 +1,73 @@
+import 'dart:math';
+
 import 'package:flame/components.dart';
 import 'package:flutter/painting.dart';
 
-/// Zero-allocation, cached floating text indicator.
+/// Zero-allocation, GPU-friendly floating text indicator.
 /// Extends Component so it naturally scales with the camera viewfinder in world space.
+/// Uses direct alpha text styling and pop scaling instead of expensive canvas.saveLayer.
 class FloatingText extends Component {
   Offset pos;
   double life = 1.0;
-  final TextPainter textPainter;
+  final String _text;
+  final Color _color;
+  final double _size;
+  final TextPainter _textPainter = TextPainter(
+    textDirection: TextDirection.ltr,
+  );
 
-  FloatingText(String text, this.pos, Color color, double size)
-      : textPainter = TextPainter(
-          text: TextSpan(
-            text: text,
-            style: TextStyle(
-              color: color,
-              fontSize: size,
-              fontWeight: FontWeight.w900,
-              letterSpacing: 1.4,
-              shadows: const [
-                Shadow(
-                  color: Color(0xDD000000),
-                  blurRadius: 4,
-                  offset: Offset(1, 1),
-                ),
-              ],
-            ),
+  FloatingText(this._text, this.pos, this._color, this._size) {
+    _updateTextPainter();
+  }
+
+  void _updateTextPainter() {
+    final currentAlpha = life.clamp(0.0, 1.0);
+    _textPainter.text = TextSpan(
+      text: _text,
+      style: TextStyle(
+        color: _color.withValues(alpha: currentAlpha),
+        fontSize: _size,
+        fontWeight: FontWeight.w900,
+        letterSpacing: 1.4,
+        shadows: [
+          Shadow(
+            color:
+                const Color(0xDD000000).withValues(alpha: currentAlpha * 0.7),
+            blurRadius: 4,
+            offset: const Offset(1, 1),
           ),
-          textDirection: TextDirection.ltr,
-        )..layout();
+        ],
+      ),
+    );
+    _textPainter.layout();
+  }
 
   bool get isDone => life <= 0;
 
   @override
   void update(double dt) {
     super.update(dt);
-    pos = Offset(pos.dx, pos.dy - dt * 45);
-    life = (life - dt * 1.5).clamp(0.0, 1.0);
+    pos = Offset(pos.dx, pos.dy - dt * 50);
+    life = (life - dt * 1.6).clamp(0.0, 1.0);
     if (life <= 0) {
       removeFromParent();
+    } else {
+      _updateTextPainter();
     }
   }
 
   @override
   void render(Canvas canvas) {
     if (life <= 0) return;
-    final paintOffset = Offset(pos.dx - textPainter.width / 2, pos.dy);
-    if (life >= 0.9) {
-      textPainter.paint(canvas, paintOffset);
-    } else {
-      // Fade out cleanly without layout recalculation
-      canvas.saveLayer(
-        Rect.fromLTWH(
-          paintOffset.dx - 8,
-          paintOffset.dy - 4,
-          textPainter.width + 16,
-          textPainter.height + 8,
-        ),
-        Paint()..color = const Color(0xFFFFFFFF).withValues(alpha: life),
-      );
-      textPainter.paint(canvas, paintOffset);
-      canvas.restore();
-    }
+    canvas.save();
+    canvas.translate(pos.dx, pos.dy);
+    // Punchy pop-in scale curve
+    final popScale = (0.95 + sin(life * pi * 0.5) * 0.25).clamp(0.8, 1.25);
+    canvas.scale(popScale, popScale);
+    _textPainter.paint(
+      canvas,
+      Offset(-_textPainter.width / 2, -_textPainter.height / 2),
+    );
+    canvas.restore();
   }
 }

--- a/shorebird_runner/lib/game/floating_text.dart
+++ b/shorebird_runner/lib/game/floating_text.dart
@@ -20,6 +20,8 @@ class FloatingText extends Component {
     _updateTextPainter();
   }
 
+  int _lastAlphaStep = -1;
+
   void _updateTextPainter() {
     final currentAlpha = life.clamp(0.0, 1.0);
     _textPainter.text = TextSpan(
@@ -52,7 +54,11 @@ class FloatingText extends Component {
     if (life <= 0) {
       removeFromParent();
     } else {
-      _updateTextPainter();
+      final step = (life * 8).floor();
+      if (step != _lastAlphaStep) {
+        _lastAlphaStep = step;
+        _updateTextPainter();
+      }
     }
   }
 

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -49,9 +49,15 @@ class ShorebirdRunnerGame extends FlameGame
   late final Player _player;
   late final Hud _hud;
   late final LaneWorld _laneWorld;
+  late final SpeedWarpFx _speedWarp;
   final List<Obstacle> _obstacles = [];
   final List<Patch> _patches = [];
   final _rng = Random();
+
+  // Reusable vignette paints
+  final Paint _crashFlashPaint = Paint();
+  final Paint _crashVignettePaint = Paint();
+  Rect? _lastVignetteRect;
 
   // Screen shake & crash flash
   double _screenShake = 0;
@@ -79,6 +85,9 @@ class ShorebirdRunnerGame extends FlameGame
     _laneWorld = LaneWorld();
     await world.add(_laneWorld);
 
+    _speedWarp = SpeedWarpFx();
+    await world.add(_speedWarp);
+
     _player = Player(currentLane: 1, skin: skin);
     await world.add(_player);
 
@@ -91,6 +100,7 @@ class ShorebirdRunnerGame extends FlameGame
   void onGameResize(Vector2 size) {
     super.onGameResize(size);
     GameConfig.updateDimensions(size.x, size.y);
+    _lastVignetteRect = null;
   }
 
   @override
@@ -105,6 +115,8 @@ class ShorebirdRunnerGame extends FlameGame
     _hud.elapsed = _elapsed;
     _hud.totalPatches = totalPatches;
     _laneWorld.totalPatches = totalPatches;
+    _speedWarp.isHotReload = _player.isInvincible;
+    _speedWarp.speedMultiplier = currentLevel.speedMultiplier;
 
     // Survival points
     _timePointTimer += safeDt;
@@ -139,19 +151,21 @@ class ShorebirdRunnerGame extends FlameGame
 
     // Hot Reload Magnetic Pull on Collectibles
     if (_player.isInvincible) {
-      for (final p in _patches) {
+      for (int i = 0; i < _patches.length; i++) {
+        final p = _patches[i];
         if (!p.isCollected && p.depth > 0.10) {
           p.attractTowards(_player.currentLane, safeDt);
         }
       }
     }
 
-    // Update obstacles
-    for (final o in List.of(_obstacles)) {
+    // Zero-allocation backwards loop for obstacles
+    for (int i = _obstacles.length - 1; i >= 0; i--) {
+      final o = _obstacles[i];
       o.totalPatches = totalPatches;
       if (o.isPastPlayer) {
         _clearedObstacles.remove(o);
-        _obstacles.remove(o);
+        _obstacles.removeAt(i);
         world.remove(o);
         continue;
       }
@@ -161,11 +175,12 @@ class ShorebirdRunnerGame extends FlameGame
       }
     }
 
-    // Update patches
-    for (final p in List.of(_patches)) {
+    // Zero-allocation backwards loop for patches
+    for (int i = _patches.length - 1; i >= 0; i--) {
+      final p = _patches[i];
       p.totalPatches = totalPatches;
       if (p.isDone || p.isPastPlayer) {
-        _patches.remove(p);
+        _patches.removeAt(i);
         world.remove(p);
         continue;
       }
@@ -175,6 +190,9 @@ class ShorebirdRunnerGame extends FlameGame
         _onPatchCollected(p);
       }
     }
+
+    // Dynamic Camera Banking (leans smoothly into turns)
+    camera.viewfinder.angle = -_player.rollAngle * 0.14;
 
     // Screen shake
     if (_screenShake > 0) {
@@ -196,26 +214,27 @@ class ShorebirdRunnerGame extends FlameGame
   void render(Canvas canvas) {
     super.render(canvas);
 
-    // Fullscreen Red Danger Flash & Vignette (covers entire canvas seamlessly)
+    // Fullscreen Red Danger Flash & Vignette (zero per-frame allocations)
     if (_crashFlash > 0) {
       final fullRect = Rect.fromLTWH(0, 0, size.x, size.y);
-      canvas.drawRect(
-        fullRect,
-        Paint()
-          ..color =
-              const Color(0xFFFF2A4B).withValues(alpha: _crashFlash * 0.45),
-      );
-      // Soft radial edge vignette
-      final vignettePaint = Paint()
-        ..shader = RadialGradient(
+      _crashFlashPaint.color =
+          const Color(0xFFFF2A4B).withValues(alpha: _crashFlash * 0.45);
+      canvas.drawRect(fullRect, _crashFlashPaint);
+
+      if (_lastVignetteRect != fullRect) {
+        _lastVignetteRect = fullRect;
+        _crashVignettePaint.shader = const RadialGradient(
           center: Alignment.center,
           radius: 0.85,
           colors: [
-            const Color(0x00000000),
-            const Color(0xFFFF1744).withValues(alpha: _crashFlash * 0.75),
+            Color(0x00000000),
+            Color(0xFFFF1744),
           ],
         ).createShader(fullRect);
-      canvas.drawRect(fullRect, vignettePaint);
+      }
+      _crashVignettePaint.color =
+          const Color(0xFFFFFFFF).withValues(alpha: _crashFlash * 0.75);
+      canvas.drawRect(fullRect, _crashVignettePaint);
     }
   }
 
@@ -559,9 +578,21 @@ class ShorebirdRunnerGame extends FlameGame
     }
   }
 
-  void moveToLane(int lane) => _player.moveToLane(lane);
-  void moveLeft() => _player.moveLeft();
-  void moveRight() => _player.moveRight();
+  void moveToLane(int lane) {
+    _player.moveToLane(lane);
+    _laneWorld.triggerLanePulse(lane);
+  }
+
+  void moveLeft() {
+    _player.moveLeft();
+    _laneWorld.triggerLanePulse(_player.currentLane);
+  }
+
+  void moveRight() {
+    _player.moveRight();
+    _laneWorld.triggerLanePulse(_player.currentLane);
+  }
+
   void jump() => _player.jump();
   void slide() => _player.slide();
   int get currentLane => _player.currentLane;
@@ -575,11 +606,11 @@ class ShorebirdRunnerGame extends FlameGame
 
     // Directly click on the desired lane to move player there
     if (tapX < size.x * 0.36) {
-      _player.moveToLane(0);
+      moveToLane(0);
     } else if (tapX > size.x * 0.64) {
-      _player.moveToLane(2);
+      moveToLane(2);
     } else {
-      _player.moveToLane(1);
+      moveToLane(1);
     }
   }
 }

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -483,8 +483,8 @@ class ShorebirdRunnerGame extends FlameGame
     HighScoreService.save(score).then((_) async {
       highScore = await HighScoreService.load();
       await Future.delayed(const Duration(milliseconds: 650));
+      if (!isMounted) return;
       onGameOver(score, totalPatches, currentLevel);
-      overlays.add('game_over');
     });
   }
 

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -115,14 +115,16 @@ class ShorebirdRunnerGame extends FlameGame
     _hud.elapsed = _elapsed;
     _hud.totalPatches = totalPatches;
     _laneWorld.totalPatches = totalPatches;
+    _laneWorld.isInvincible = _player.isInvincible;
     _speedWarp.isHotReload = _player.isInvincible;
-    _speedWarp.speedMultiplier = currentLevel.speedMultiplier;
+    _speedWarp.speedMultiplier =
+        currentLevel.speedMultiplier * (_player.isInvincible ? 1.65 : 1.0);
 
-    // Survival points
-    _timePointTimer += safeDt;
+    // Survival points (boosted ticking and double points during invincibility)
+    _timePointTimer += safeDt * (_player.isInvincible ? 2.0 : 1.0);
     if (_timePointTimer >= GameConfig.timePointInterval) {
       _timePointTimer -= GameConfig.timePointInterval;
-      score += GameConfig.timePoints;
+      score += GameConfig.timePoints * (_player.isInvincible ? 2 : 1);
       _hud.score = score;
     }
 
@@ -133,16 +135,16 @@ class ShorebirdRunnerGame extends FlameGame
       onScoreUpdate?.call(score, totalPatches, currentLevel, !_isOver);
     }
 
-    // Spawn obstacles (guaranteeing at least 1 open lane)
-    _obstacleTimer += safeDt;
+    // Spawn obstacles (faster spawn to provide smash targets during invincibility)
+    _obstacleTimer += safeDt * (_player.isInvincible ? 1.5 : 1.0);
     final obstInterval = GameConfig.obstacleInterval(totalPatches);
     if (_obstacleTimer >= obstInterval) {
       _obstacleTimer = 0;
       _spawnObstacles();
     }
 
-    // Spawn patches
-    _patchTimer += safeDt;
+    // Spawn patches (boosted patch flow during invincibility)
+    _patchTimer += safeDt * (_player.isInvincible ? 1.65 : 1.0);
     final patchInterval = GameConfig.patchInterval(totalPatches);
     if (_patchTimer >= patchInterval) {
       _patchTimer = 0;
@@ -163,6 +165,7 @@ class ShorebirdRunnerGame extends FlameGame
     for (int i = _obstacles.length - 1; i >= 0; i--) {
       final o = _obstacles[i];
       o.totalPatches = totalPatches;
+      o.isInvincible = _player.isInvincible;
       if (o.isPastPlayer) {
         _clearedObstacles.remove(o);
         _obstacles.removeAt(i);
@@ -179,6 +182,7 @@ class ShorebirdRunnerGame extends FlameGame
     for (int i = _patches.length - 1; i >= 0; i--) {
       final p = _patches[i];
       p.totalPatches = totalPatches;
+      p.isInvincible = _player.isInvincible;
       if (p.isDone || p.isPastPlayer) {
         _patches.removeAt(i);
         world.remove(p);
@@ -369,25 +373,29 @@ class ShorebirdRunnerGame extends FlameGame
     final pos = p.worldPosition;
     totalPatches++;
     _combo++;
-    score += GameConfig.patchPoints;
+
+    final isBoosted = _player.isInvincible;
+    final regularPoints =
+        isBoosted ? GameConfig.patchPoints * 2 : GameConfig.patchPoints;
 
     if (p.isHotReloadBooster) {
       _player
           .triggerHotReload(6.0); // 6 seconds of invincible Hot Reload power!
       _hud.triggerComboFlash();
       _screenShake = 0.5;
+      score += 500;
       _addFloatingText(
         '🔥 HOT RELOAD! +500',
         pos,
         const Color(0xFFFF9100),
         size: 20,
       );
-      score += 500;
     } else {
+      score += regularPoints;
       _addFloatingText(
-        '+${GameConfig.patchPoints} 🐤 PATCH!',
+        isBoosted ? '+$regularPoints ⚡2X PATCH!' : '+$regularPoints 🐤 PATCH!',
         pos,
-        const Color(0xFFFFD700),
+        isBoosted ? const Color(0xFF00FFCC) : const Color(0xFFFFD700),
       );
     }
 

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -191,9 +191,6 @@ class ShorebirdRunnerGame extends FlameGame
       }
     }
 
-    // Dynamic Camera Banking (leans smoothly into turns)
-    camera.viewfinder.angle = -_player.rollAngle * 0.14;
-
     // Screen shake
     if (_screenShake > 0) {
       _screenShake = (_screenShake - safeDt * 3.5).clamp(0, 10);
@@ -578,20 +575,9 @@ class ShorebirdRunnerGame extends FlameGame
     }
   }
 
-  void moveToLane(int lane) {
-    _player.moveToLane(lane);
-    _laneWorld.triggerLanePulse(lane);
-  }
-
-  void moveLeft() {
-    _player.moveLeft();
-    _laneWorld.triggerLanePulse(_player.currentLane);
-  }
-
-  void moveRight() {
-    _player.moveRight();
-    _laneWorld.triggerLanePulse(_player.currentLane);
-  }
+  void moveToLane(int lane) => _player.moveToLane(lane);
+  void moveLeft() => _player.moveLeft();
+  void moveRight() => _player.moveRight();
 
   void jump() => _player.jump();
   void slide() => _player.slide();

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -44,8 +44,8 @@ class ShorebirdRunnerGame extends FlameGame
   double _patchTimer = 0;
   double _timePointTimer = 0;
   double _scoreBroadcastTimer = 0;
-  // Hot Reload Booster pacing: strictly gated, rare (5%), and with cooldowns
-  double _boosterCooldownTimer = 18.0;
+  // Hot Reload Booster pacing: paced reliably every 11-14 patches (~once per tier milestone)
+  int _patchesSinceLastBooster = 0;
 
   // Components
   late final Player _player;
@@ -151,10 +151,6 @@ class ShorebirdRunnerGame extends FlameGame
     if (_patchTimer >= patchInterval) {
       _patchTimer = 0;
       _spawnPatch();
-    }
-
-    if (_boosterCooldownTimer > 0) {
-      _boosterCooldownTimer -= safeDt;
     }
 
     // Hot Reload Magnetic Pull on Collectibles (regular patches only; never pulls rare boosters)
@@ -272,18 +268,19 @@ class ShorebirdRunnerGame extends FlameGame
 
   void _spawnPatch() {
     final lane = _rng.nextInt(GameConfig.laneCount);
-    // Boosters are rare, difficult to obtain, and strictly gated:
-    // 1. Never spawn during active Hot Reload
-    // 2. Cooldown timer must have elapsed (min 25s between boosters)
-    // 3. Must have collected at least 10 patches
-    // 4. Low 5% spawn chance once all conditions are satisfied
-    final canSpawnBooster = !_player.isInvincible &&
-        _boosterCooldownTimer <= 0 &&
-        totalPatches >= 10;
-    final isBooster = canSpawnBooster && (_rng.nextDouble() < 0.05);
+    _patchesSinceLastBooster++;
+
+    // Paced powerup delivery:
+    // - Never spawns during active Hot Reload (invincibility)
+    // - Requires at least 11 regular patches between boosters to prevent spam
+    // - Spawns reliably between patches 11-14 (~once per tier milestone)
+    final canSpawnBooster =
+        !_player.isInvincible && _patchesSinceLastBooster >= 11;
+    final isBooster = canSpawnBooster &&
+        (_patchesSinceLastBooster >= 14 || _rng.nextDouble() < 0.40);
 
     if (isBooster) {
-      _boosterCooldownTimer = 25.0;
+      _patchesSinceLastBooster = 0;
     }
 
     final patch = Patch(
@@ -397,7 +394,7 @@ class ShorebirdRunnerGame extends FlameGame
     if (p.isHotReloadBooster) {
       // 4.5 seconds of high-octane invincibility
       _player.triggerHotReload(4.5);
-      _boosterCooldownTimer = 28.0; // Strict cooldown before another can spawn
+      _patchesSinceLastBooster = 0;
       _hud.triggerComboFlash();
       _screenShake = 0.5;
       score += 500;

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -252,9 +252,8 @@ class ShorebirdRunnerGame extends FlameGame
     world.add(obs1);
 
     if (spawnDouble) {
-      // Pick a second distinct lane - guarantees exactly 1 open lane to dodge into!
-      final otherLanes = [0, 1, 2]..remove(firstLane);
-      final secondLane = otherLanes[_rng.nextInt(otherLanes.length)];
+      // Pick a second distinct lane - guarantees exactly 1 open lane to dodge into (zero allocations)
+      final secondLane = (firstLane + 1 + _rng.nextInt(2)) % 3;
       final secondType =
           ObstacleType.values[_rng.nextInt(ObstacleType.values.length)];
 

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -324,7 +324,7 @@ class ShorebirdRunnerGame extends FlameGame
         _hud.score = score;
         AudioService.playStomp();
         _addFloatingText(
-          '🦘 LEAP! +150',
+          'LEAP! +150',
           o.worldPosition,
           const Color(0xFF00E5FF),
           size: 17,
@@ -341,7 +341,7 @@ class ShorebirdRunnerGame extends FlameGame
         _hud.score = score;
         AudioService.playSlide();
         _addFloatingText(
-          '⚡ SLIDE! +150',
+          'SLIDE! +150',
           o.worldPosition,
           const Color(0xFFFFD700),
           size: 17,
@@ -367,7 +367,7 @@ class ShorebirdRunnerGame extends FlameGame
     _screenShake = 0.8;
 
     _addFloatingText(
-      '💥 SQUASHED! +300',
+      'SQUASHED! +300',
       o.worldPosition,
       const Color(0xFF00FF88),
       size: 18,
@@ -402,7 +402,7 @@ class ShorebirdRunnerGame extends FlameGame
       _screenShake = 0.5;
       score += 500;
       _addFloatingText(
-        '🔥 HOT RELOAD! +500',
+        'HOT RELOAD! +500',
         pos,
         const Color(0xFFFF9100),
         size: 20,
@@ -410,7 +410,7 @@ class ShorebirdRunnerGame extends FlameGame
     } else {
       score += regularPoints;
       _addFloatingText(
-        isBoosted ? '+$regularPoints ⚡2X PATCH!' : '+$regularPoints 🐤 PATCH!',
+        isBoosted ? '+$regularPoints (2X PATCH)' : '+$regularPoints PATCH',
         pos,
         isBoosted ? const Color(0xFF00FFCC) : const Color(0xFFFFD700),
       );
@@ -421,7 +421,7 @@ class ShorebirdRunnerGame extends FlameGame
       _hud.triggerComboFlash();
       AudioService.playCombo();
       _addFloatingText(
-        'COMBO ×$_combo! +${GameConfig.comboBonus}',
+        'COMBO x$_combo! +${GameConfig.comboBonus}',
         Offset(pos.dx, pos.dy - 30),
         const Color(GameConfig.colorAmber),
       );
@@ -447,7 +447,7 @@ class ShorebirdRunnerGame extends FlameGame
 
     AudioService.playMiss();
     _addFloatingText(
-      '-${GameConfig.missedPatchPenalty} 🐤 MISSED!',
+      '-${GameConfig.missedPatchPenalty} MISSED!',
       Offset(pos.dx, GameConfig.nearY - 20),
       const Color(0xFFFF2A4B),
       size: 18,
@@ -464,7 +464,7 @@ class ShorebirdRunnerGame extends FlameGame
     _screenShake = 1.0;
 
     _addFloatingText(
-      '${newLevel.emoji} ${newLevel.name} UNLOCKED! +${GameConfig.levelUpBonus}',
+      '${newLevel.name} UNLOCKED! +${GameConfig.levelUpBonus}',
       Offset(GameConfig.designWidth / 2, 260),
       Color(newLevel.accentColor),
       size: 24,

--- a/shorebird_runner/lib/game/shorebird_runner_game.dart
+++ b/shorebird_runner/lib/game/shorebird_runner_game.dart
@@ -44,6 +44,8 @@ class ShorebirdRunnerGame extends FlameGame
   double _patchTimer = 0;
   double _timePointTimer = 0;
   double _scoreBroadcastTimer = 0;
+  // Hot Reload Booster pacing: strictly gated, rare (5%), and with cooldowns
+  double _boosterCooldownTimer = 18.0;
 
   // Components
   late final Player _player;
@@ -143,19 +145,23 @@ class ShorebirdRunnerGame extends FlameGame
       _spawnObstacles();
     }
 
-    // Spawn patches (boosted patch flow during invincibility)
-    _patchTimer += safeDt * (_player.isInvincible ? 1.65 : 1.0);
+    // Spawn patches
+    _patchTimer += safeDt * (_player.isInvincible ? 1.15 : 1.0);
     final patchInterval = GameConfig.patchInterval(totalPatches);
     if (_patchTimer >= patchInterval) {
       _patchTimer = 0;
       _spawnPatch();
     }
 
-    // Hot Reload Magnetic Pull on Collectibles
+    if (_boosterCooldownTimer > 0) {
+      _boosterCooldownTimer -= safeDt;
+    }
+
+    // Hot Reload Magnetic Pull on Collectibles (regular patches only; never pulls rare boosters)
     if (_player.isInvincible) {
       for (int i = 0; i < _patches.length; i++) {
         final p = _patches[i];
-        if (!p.isCollected && p.depth > 0.10) {
+        if (!p.isCollected && !p.isHotReloadBooster && p.depth > 0.10) {
           p.attractTowards(_player.currentLane, safeDt);
         }
       }
@@ -266,8 +272,19 @@ class ShorebirdRunnerGame extends FlameGame
 
   void _spawnPatch() {
     final lane = _rng.nextInt(GameConfig.laneCount);
-    // 16% chance of spawning a glowing Hot Reload Booster patch
-    final isBooster = _rng.nextDouble() < 0.16;
+    // Boosters are rare, difficult to obtain, and strictly gated:
+    // 1. Never spawn during active Hot Reload
+    // 2. Cooldown timer must have elapsed (min 25s between boosters)
+    // 3. Must have collected at least 10 patches
+    // 4. Low 5% spawn chance once all conditions are satisfied
+    final canSpawnBooster = !_player.isInvincible &&
+        _boosterCooldownTimer <= 0 &&
+        totalPatches >= 10;
+    final isBooster = canSpawnBooster && (_rng.nextDouble() < 0.05);
+
+    if (isBooster) {
+      _boosterCooldownTimer = 25.0;
+    }
 
     final patch = Patch(
       lane: lane,
@@ -378,8 +395,9 @@ class ShorebirdRunnerGame extends FlameGame
         isBoosted ? GameConfig.patchPoints * 2 : GameConfig.patchPoints;
 
     if (p.isHotReloadBooster) {
-      _player
-          .triggerHotReload(6.0); // 6 seconds of invincible Hot Reload power!
+      // 4.5 seconds of high-octane invincibility
+      _player.triggerHotReload(4.5);
+      _boosterCooldownTimer = 28.0; // Strict cooldown before another can spawn
       _hud.triggerComboFlash();
       _screenShake = 0.5;
       score += 500;

--- a/shorebird_runner/lib/game/utils/game_config.dart
+++ b/shorebird_runner/lib/game/utils/game_config.dart
@@ -181,9 +181,11 @@ class GameConfig {
   }
 
   // ── Dynamic parameters ─────────────────────────────────────────────────────
-  static double scrollSpeed(int patches) {
+  static double scrollSpeed(int patches, {bool isInvincible = false}) {
     const base = 0.65;
-    return base * levelFor(patches).speedMultiplier;
+    final speedMultiplier = levelFor(patches).speedMultiplier;
+    final invincibleBoost = isInvincible ? 1.65 : 1.0;
+    return base * speedMultiplier * invincibleBoost;
   }
 
   static double obstacleInterval(int patches) {

--- a/shorebird_runner/web/index.html
+++ b/shorebird_runner/web/index.html
@@ -24,6 +24,11 @@
   <title>Patch Rush — by Shorebird</title>
   <link rel="manifest" href="manifest.json">
 
+  <!-- Font preconnect & Noto Color Emoji for complete cross-platform emoji rendering -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap" rel="stylesheet">
+
   <style>
     * {
       margin: 0;
@@ -37,6 +42,7 @@
       height: 100%;
       background: #0A0E1A;
       overflow: hidden;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Color Emoji', sans-serif;
     }
 
     /* Custom loading screen */
@@ -102,7 +108,7 @@
     const bar = document.getElementById('loading-bar');
     const interval = setInterval(() => {
       progress = Math.min(progress + Math.random() * 15, 90);
-      bar.style.width = progress + '%';
+      if (bar) bar.style.width = progress + '%';
     }, 200);
 
     // flutter-first-frame is the real Flutter web event fired after the
@@ -110,12 +116,18 @@
     // loading screen.
     window.addEventListener('flutter-first-frame', function () {
       clearInterval(interval);
-      bar.style.width = '100%';
+      if (bar) bar.style.width = '100%';
       setTimeout(() => {
         const loading = document.getElementById('loading');
-        loading.style.opacity = '0';
-        loading.style.transition = 'opacity 0.5s ease';
-        setTimeout(() => loading.remove(), 500);
+        if (loading) {
+          loading.style.opacity = '0';
+          loading.style.transition = 'opacity 0.5s ease';
+          setTimeout(() => {
+            if (loading && loading.parentNode) {
+              loading.remove();
+            }
+          }, 500);
+        }
       }, 300);
     });
     // Web Audio arcade sound synthesizer


### PR DESCRIPTION
## Overview
This PR brings significant performance optimizations, visual polish, gameplay rebalancing, and web stability fixes to `shorebird_runner`.

### Key Improvements

1. **Eliminate Motion Sickness / UI Flickering on Lane Changes**:
   - Removed aggressive camera banking/tilting and road perspective shifts during lane changes.
   - Cleanly aligned road geometry to 3 distinct lanes without misleading extraneous rail dividers.

2. **60–120 FPS Mobile Performance & Zero GC Stutters**:
   - **Shader Caching**: Pre-cached static shaders for the HUD panel, sheen, border, and level progress bar.
   - **Pylon Allocations**: Replaced 16 dynamic linear shaders and 48 `Paint()` allocations per frame in `LaneWorld` with pre-allocated reusable paints and solid lerped colors (~7,600 fewer GC allocations/sec at 120 FPS).
   - **Text Layout Overhead**: Quantized alpha steps in `FloatingText` to reduce expensive HarfBuzz/Skia paragraph measuring by ~90%.
   - **Zero-Allocation Closures & Loops**: Replaced anonymous closures in `Player.worldPosition`/`_drawShadow` with a direct `groundPosition` getter, and replaced `.removeWhere` with backwards-indexed loops.

3. **Hot Reload Powerup Rebalancing**:
   - Tuned powerup pacing to appear predictably every 11–14 patches (~once per tier milestone) rather than chaining back-to-back or disappearing.
   - Hot Reload boosters are immune to magnetic pull, requiring players to actively steer into the lane.
   - Powerup duration tuned to 4.5s of punchy high-velocity invincibility and 2x patch points.

4. **Web Stability & Noto Font Fix**:
   - **Fixed Hot Restart TypeError**: Guarded `#loading` and `#loading-bar` DOM lookups in `web/index.html` during `flutter-first-frame` so hot restarts never throw `TypeError: Cannot read properties of null (reading 'style')`.
   - **Eliminated Canvas Noto Font Dependencies**: Replaced canvas `TextPainter` emojis on patches (`🐤`) with a multi-layer vector Shorebird emblem, preventing missing Noto font warnings and runtime canvas style crashes. Linked Google's `Noto Color Emoji` font in `index.html`.
   - **Flame Overlay Assertion Guard**: Removed obsolete `overlays.add('game_over')` call and guarded `onGameOver` with `isMounted`.

### Verification
- `dart format .` passed.
- `flutter analyze` passed with 0 issues.
- `flutter test` passed.