### PR TITLE
feat(shorebird_runner): in-game leaderboard with event filter, search, and optional phone

### DIFF
--- a/shorebird_runner/lib/features/lead_capture/bloc/lead_capture_state.dart
+++ b/shorebird_runner/lib/features/lead_capture/bloc/lead_capture_state.dart
@@ -29,6 +29,7 @@ class LeadCaptureState extends Equatable {
       RegExp(r'^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$')
           .hasMatch(email.trim());
   bool get isPhoneValid =>
+      phone.trim().isEmpty ||
       phone.trim().replaceAll(RegExp(r'[^0-9]'), '').length >= 6;
   bool get isOrgValid => organization.trim().isNotEmpty;
 

--- a/shorebird_runner/lib/features/lead_capture/widgets/lead_capture_dialog.dart
+++ b/shorebird_runner/lib/features/lead_capture/widgets/lead_capture_dialog.dart
@@ -312,21 +312,23 @@ class _LeadCaptureDialogState extends State<LeadCaptureDialog> {
 
                               const SizedBox(height: 16),
 
-                              // Field 3: Phone
+                              // Field 3: Phone (Optional)
                               _buildField(
                                 controller: _phoneController,
-                                label: 'CONTACT NUMBER',
+                                label: 'CONTACT NUMBER (OPTIONAL)',
                                 hint: 'e.g. +1 (555) 019-2834',
                                 icon: Icons.phone_outlined,
                                 keyboardType: TextInputType.phone,
                                 validator: (val) {
-                                  if (val == null ||
-                                      val
-                                              .trim()
-                                              .replaceAll(RegExp(r'[^0-9]'), '')
-                                              .length <
-                                          6) {
-                                    return 'Please enter a valid phone number';
+                                  if (val == null || val.trim().isEmpty) {
+                                    return null;
+                                  }
+                                  if (val
+                                          .trim()
+                                          .replaceAll(RegExp(r'[^0-9]'), '')
+                                          .length <
+                                      6) {
+                                    return 'Please enter a valid phone number or leave blank';
                                   }
                                   return null;
                                 },

--- a/shorebird_runner/lib/features/leaderboard/bloc/leaderboard_bloc.dart
+++ b/shorebird_runner/lib/features/leaderboard/bloc/leaderboard_bloc.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shorebird_runner/features/leaderboard/bloc/leaderboard_event.dart';
+import 'package:shorebird_runner/features/leaderboard/bloc/leaderboard_state.dart';
+import 'package:shorebird_runner/features/leaderboard/data/i_leaderboard_repository.dart';
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+export 'leaderboard_event.dart';
+export 'leaderboard_state.dart';
+
+class LeaderboardBloc extends Bloc<LeaderboardEvent, LeaderboardState> {
+  final ILeaderboardRepository repository;
+
+  LeaderboardBloc({required this.repository})
+      : super(const LeaderboardState()) {
+    on<FetchLeaderboard>(_onFetchLeaderboard);
+    on<FilterLeaderboardByEvent>(_onFilterByEvent);
+    on<SearchLeaderboard>(_onSearchLeaderboard);
+    on<RecordScore>(_onRecordScore);
+    on<RefreshLeaderboard>(_onRefreshLeaderboard);
+  }
+
+  Future<void> _onFetchLeaderboard(
+    FetchLeaderboard event,
+    Emitter<LeaderboardState> emit,
+  ) async {
+    emit(state.copyWith(status: LeaderboardStatus.loading));
+
+    final targetEvent = event.initialEvent ?? state.selectedEvent;
+
+    try {
+      final scores = await repository.getScores();
+      final eventList = await repository.getEvents();
+
+      final available = ['All Events'];
+      for (final e in eventList) {
+        if (!available.contains(e)) available.add(e);
+      }
+
+      // Ensure active event is in available list
+      if (targetEvent.isNotEmpty && !available.contains(targetEvent)) {
+        available.add(targetEvent);
+      }
+
+      final filtered = _applyFilterAndSearch(
+        entries: scores,
+        event: targetEvent,
+        query: state.searchQuery,
+      );
+
+      emit(
+        state.copyWith(
+          status: LeaderboardStatus.success,
+          allEntries: scores,
+          filteredEntries: filtered,
+          selectedEvent: targetEvent,
+          availableEvents: available,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          status: LeaderboardStatus.failure,
+          errorMessage: 'Failed to load leaderboard scores.',
+        ),
+      );
+    }
+  }
+
+  void _onFilterByEvent(
+    FilterLeaderboardByEvent event,
+    Emitter<LeaderboardState> emit,
+  ) {
+    final newEvent = event.event ?? 'All Events';
+    final filtered = _applyFilterAndSearch(
+      entries: state.allEntries,
+      event: newEvent,
+      query: state.searchQuery,
+    );
+
+    emit(
+      state.copyWith(
+        selectedEvent: newEvent,
+        filteredEntries: filtered,
+      ),
+    );
+  }
+
+  void _onSearchLeaderboard(
+    SearchLeaderboard event,
+    Emitter<LeaderboardState> emit,
+  ) {
+    final filtered = _applyFilterAndSearch(
+      entries: state.allEntries,
+      event: state.selectedEvent,
+      query: event.query,
+    );
+
+    emit(
+      state.copyWith(
+        searchQuery: event.query,
+        filteredEntries: filtered,
+      ),
+    );
+  }
+
+  Future<void> _onRecordScore(
+    RecordScore event,
+    Emitter<LeaderboardState> emit,
+  ) async {
+    try {
+      await repository.submitScore(event.entry);
+      add(const RefreshLeaderboard());
+    } catch (_) {}
+  }
+
+  Future<void> _onRefreshLeaderboard(
+    RefreshLeaderboard event,
+    Emitter<LeaderboardState> emit,
+  ) async {
+    try {
+      final scores = await repository.getScores();
+      final eventList = await repository.getEvents();
+
+      final available = ['All Events'];
+      for (final e in eventList) {
+        if (!available.contains(e)) available.add(e);
+      }
+
+      final filtered = _applyFilterAndSearch(
+        entries: scores,
+        event: state.selectedEvent,
+        query: state.searchQuery,
+      );
+
+      emit(
+        state.copyWith(
+          status: LeaderboardStatus.success,
+          allEntries: scores,
+          filteredEntries: filtered,
+          availableEvents: available,
+        ),
+      );
+    } catch (_) {}
+  }
+
+  List<LeaderboardEntryModel> _applyFilterAndSearch({
+    required List<LeaderboardEntryModel> entries,
+    required String event,
+    required String query,
+  }) {
+    var result = List<LeaderboardEntryModel>.from(entries);
+
+    // 1. Event filter
+    if (event != 'All Events' && event.trim().isNotEmpty) {
+      final normalized = event.trim().toLowerCase();
+      result = result
+          .where((e) => e.event.trim().toLowerCase() == normalized)
+          .toList();
+    }
+
+    // 2. Search query filter
+    if (query.trim().isNotEmpty) {
+      final q = query.trim().toLowerCase();
+      result = result.where((e) {
+        final matchName = e.playerName.toLowerCase().contains(q);
+        final matchOrg = e.organization.toLowerCase().contains(q);
+        final matchEvent = e.event.toLowerCase().contains(q);
+        return matchName || matchOrg || matchEvent;
+      }).toList();
+    }
+
+    result.sort((a, b) => b.score.compareTo(a.score));
+    return result;
+  }
+}

--- a/shorebird_runner/lib/features/leaderboard/bloc/leaderboard_event.dart
+++ b/shorebird_runner/lib/features/leaderboard/bloc/leaderboard_event.dart
@@ -1,0 +1,49 @@
+import 'package:equatable/equatable.dart';
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+abstract class LeaderboardEvent extends Equatable {
+  const LeaderboardEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class FetchLeaderboard extends LeaderboardEvent {
+  final String? initialEvent;
+
+  const FetchLeaderboard({this.initialEvent});
+
+  @override
+  List<Object?> get props => [initialEvent];
+}
+
+class FilterLeaderboardByEvent extends LeaderboardEvent {
+  final String? event;
+
+  const FilterLeaderboardByEvent(this.event);
+
+  @override
+  List<Object?> get props => [event];
+}
+
+class SearchLeaderboard extends LeaderboardEvent {
+  final String query;
+
+  const SearchLeaderboard(this.query);
+
+  @override
+  List<Object?> get props => [query];
+}
+
+class RecordScore extends LeaderboardEvent {
+  final LeaderboardEntryModel entry;
+
+  const RecordScore(this.entry);
+
+  @override
+  List<Object?> get props => [entry];
+}
+
+class RefreshLeaderboard extends LeaderboardEvent {
+  const RefreshLeaderboard();
+}

--- a/shorebird_runner/lib/features/leaderboard/bloc/leaderboard_state.dart
+++ b/shorebird_runner/lib/features/leaderboard/bloc/leaderboard_state.dart
@@ -1,0 +1,55 @@
+import 'package:equatable/equatable.dart';
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+enum LeaderboardStatus { initial, loading, success, failure }
+
+class LeaderboardState extends Equatable {
+  final LeaderboardStatus status;
+  final List<LeaderboardEntryModel> allEntries;
+  final List<LeaderboardEntryModel> filteredEntries;
+  final String selectedEvent;
+  final List<String> availableEvents;
+  final String searchQuery;
+  final String? errorMessage;
+
+  const LeaderboardState({
+    this.status = LeaderboardStatus.initial,
+    this.allEntries = const [],
+    this.filteredEntries = const [],
+    this.selectedEvent = 'All Events',
+    this.availableEvents = const ['All Events'],
+    this.searchQuery = '',
+    this.errorMessage,
+  });
+
+  LeaderboardState copyWith({
+    LeaderboardStatus? status,
+    List<LeaderboardEntryModel>? allEntries,
+    List<LeaderboardEntryModel>? filteredEntries,
+    String? selectedEvent,
+    List<String>? availableEvents,
+    String? searchQuery,
+    String? errorMessage,
+  }) {
+    return LeaderboardState(
+      status: status ?? this.status,
+      allEntries: allEntries ?? this.allEntries,
+      filteredEntries: filteredEntries ?? this.filteredEntries,
+      selectedEvent: selectedEvent ?? this.selectedEvent,
+      availableEvents: availableEvents ?? this.availableEvents,
+      searchQuery: searchQuery ?? this.searchQuery,
+      errorMessage: errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        status,
+        allEntries,
+        filteredEntries,
+        selectedEvent,
+        availableEvents,
+        searchQuery,
+        errorMessage,
+      ];
+}

--- a/shorebird_runner/lib/features/leaderboard/data/data.dart
+++ b/shorebird_runner/lib/features/leaderboard/data/data.dart
@@ -1,0 +1,3 @@
+export 'i_leaderboard_repository.dart';
+export 'local_leaderboard_repository.dart';
+export 'supabase_leaderboard_repository.dart';

--- a/shorebird_runner/lib/features/leaderboard/data/i_leaderboard_repository.dart
+++ b/shorebird_runner/lib/features/leaderboard/data/i_leaderboard_repository.dart
@@ -1,0 +1,12 @@
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+abstract class ILeaderboardRepository {
+  /// Fetches top leaderboard scores, optionally filtered by event.
+  Future<List<LeaderboardEntryModel>> getScores({String? event});
+
+  /// Submits a new score entry to the leaderboard.
+  Future<void> submitScore(LeaderboardEntryModel entry);
+
+  /// Retrieves list of distinct events available on the leaderboard.
+  Future<List<String>> getEvents();
+}

--- a/shorebird_runner/lib/features/leaderboard/data/local_leaderboard_repository.dart
+++ b/shorebird_runner/lib/features/leaderboard/data/local_leaderboard_repository.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shorebird_runner/features/leaderboard/data/i_leaderboard_repository.dart';
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+/// Local SharedPreferences implementation of [ILeaderboardRepository].
+class LocalLeaderboardRepository implements ILeaderboardRepository {
+  static const String _storageKey = 'shorebird_runner_local_leaderboard_v1';
+
+  const LocalLeaderboardRepository();
+
+  @override
+  Future<List<LeaderboardEntryModel>> getScores({String? event}) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_storageKey);
+      List<LeaderboardEntryModel> entries = [];
+
+      if (raw != null && raw.isNotEmpty) {
+        final list = jsonDecode(raw) as List<dynamic>;
+        entries = list
+            .map(
+              (e) => LeaderboardEntryModel.fromJson(
+                e as Map<String, dynamic>,
+              ),
+            )
+            .toList();
+      } else {
+        // Seed initial benchmark entries so the leaderboard has exciting targets
+        entries = _initialSeedEntries;
+        await _saveEntries(prefs, entries);
+      }
+
+      if (event != null && event.trim().isNotEmpty && event != 'All Events') {
+        final normalized = event.trim().toLowerCase();
+        entries = entries
+            .where((e) => e.event.trim().toLowerCase() == normalized)
+            .toList();
+      }
+
+      entries.sort((a, b) => b.score.compareTo(a.score));
+      return entries;
+    } catch (_) {
+      return _initialSeedEntries;
+    }
+  }
+
+  @override
+  Future<void> submitScore(LeaderboardEntryModel entry) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final current = await getScores();
+      final updated = List<LeaderboardEntryModel>.from(current)..add(entry);
+      updated.sort((a, b) => b.score.compareTo(a.score));
+      // Keep top 100
+      final capped = updated.take(100).toList();
+      await _saveEntries(prefs, capped);
+    } catch (_) {}
+  }
+
+  @override
+  Future<List<String>> getEvents() async {
+    final scores = await getScores();
+    final events = <String>{};
+    for (final s in scores) {
+      if (s.event.trim().isNotEmpty) {
+        events.add(s.event.trim());
+      }
+    }
+    return events.toList()..sort();
+  }
+
+  Future<void> _saveEntries(
+    SharedPreferences prefs,
+    List<LeaderboardEntryModel> entries,
+  ) async {
+    final raw = jsonEncode(entries.map((e) => e.toJson()).toList());
+    await prefs.setString(_storageKey, raw);
+  }
+
+  static final List<LeaderboardEntryModel> _initialSeedEntries = [
+    LeaderboardEntryModel(
+      id: 1,
+      playerName: 'Felix Angelov',
+      score: 3450,
+      patches: 58,
+      organization: 'Shorebird',
+      event: 'Global',
+      createdAt: DateTime.now().subtract(const Duration(hours: 4)),
+    ),
+    LeaderboardEntryModel(
+      id: 2,
+      playerName: 'Eric Seidel',
+      score: 3120,
+      patches: 52,
+      organization: 'Shorebird',
+      event: 'Global',
+      createdAt: DateTime.now().subtract(const Duration(hours: 6)),
+    ),
+    LeaderboardEntryModel(
+      id: 3,
+      playerName: 'Bryan Oltman',
+      score: 2890,
+      patches: 47,
+      organization: 'Shorebird',
+      event: 'Droidcon London',
+      createdAt: DateTime.now().subtract(const Duration(hours: 12)),
+    ),
+    LeaderboardEntryModel(
+      id: 4,
+      playerName: 'Sarah Chen',
+      score: 2540,
+      patches: 42,
+      organization: 'Flutter Europe',
+      event: 'FlutterCon',
+      createdAt: DateTime.now().subtract(const Duration(days: 1)),
+    ),
+    LeaderboardEntryModel(
+      id: 5,
+      playerName: 'Marcus Vance',
+      score: 2180,
+      patches: 36,
+      organization: 'Acme Mobile',
+      event: 'Droidcon London',
+      createdAt: DateTime.now().subtract(const Duration(days: 1, hours: 3)),
+    ),
+    LeaderboardEntryModel(
+      id: 6,
+      playerName: 'Elena Rostova',
+      score: 1950,
+      patches: 31,
+      organization: 'Fintech Studio',
+      event: 'FlutterCon',
+      createdAt: DateTime.now().subtract(const Duration(days: 2)),
+    ),
+  ];
+}

--- a/shorebird_runner/lib/features/leaderboard/data/supabase_leaderboard_repository.dart
+++ b/shorebird_runner/lib/features/leaderboard/data/supabase_leaderboard_repository.dart
@@ -1,0 +1,156 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:shorebird_runner/features/leaderboard/data/i_leaderboard_repository.dart';
+import 'package:shorebird_runner/features/leaderboard/data/local_leaderboard_repository.dart';
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+/// Supabase PostgREST implementation for Leaderboard.
+class SupabaseLeaderboardRepository implements ILeaderboardRepository {
+  final String supabaseUrl;
+  final String supabaseAnonKey;
+  final http.Client _httpClient;
+  final LocalLeaderboardRepository _localFallback;
+
+  SupabaseLeaderboardRepository({
+    String? supabaseUrl,
+    String? supabaseAnonKey,
+    http.Client? httpClient,
+    LocalLeaderboardRepository? localFallback,
+  })  : supabaseUrl = supabaseUrl ??
+            const String.fromEnvironment(
+              'SUPABASE_URL',
+              defaultValue: '',
+            ),
+        supabaseAnonKey = supabaseAnonKey ??
+            const String.fromEnvironment(
+              'SUPABASE_ANON_KEY',
+              defaultValue: '',
+            ),
+        _httpClient = httpClient ?? http.Client(),
+        _localFallback = localFallback ?? const LocalLeaderboardRepository();
+
+  bool get isConfigured => supabaseUrl.isNotEmpty && supabaseAnonKey.isNotEmpty;
+
+  @override
+  Future<List<LeaderboardEntryModel>> getScores({String? event}) async {
+    if (!isConfigured) {
+      return _localFallback.getScores(event: event);
+    }
+
+    try {
+      final sanitizedUrl = supabaseUrl.endsWith('/')
+          ? supabaseUrl.substring(0, supabaseUrl.length - 1)
+          : supabaseUrl;
+
+      final queryParams = <String>[
+        'select=*',
+        'order=score.desc',
+        'limit=100',
+      ];
+
+      if (event != null && event.trim().isNotEmpty && event != 'All Events') {
+        queryParams.add('event=eq.${Uri.encodeQueryComponent(event.trim())}');
+      }
+
+      final uri = Uri.parse(
+        '$sanitizedUrl/rest/v1/leaderboard?${queryParams.join('&')}',
+      );
+
+      final response = await _httpClient.get(
+        uri,
+        headers: {
+          'apikey': supabaseAnonKey,
+          'Authorization': 'Bearer $supabaseAnonKey',
+          'Accept': 'application/json',
+        },
+      ).timeout(const Duration(seconds: 10));
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        final list = jsonDecode(response.body) as List<dynamic>;
+        final entries = list
+            .map(
+              (e) => LeaderboardEntryModel.fromJson(
+                e as Map<String, dynamic>,
+              ),
+            )
+            .toList();
+
+        // If remote is empty, fall back to local seed so new users see benchmark targets
+        if (entries.isEmpty) {
+          return _localFallback.getScores(event: event);
+        }
+
+        return entries;
+      } else {
+        debugPrint(
+          '[SupabaseLeaderboardRepository] Status ${response.statusCode}: ${response.body}. Using local fallback.',
+        );
+        return _localFallback.getScores(event: event);
+      }
+    } catch (e) {
+      debugPrint(
+        '[SupabaseLeaderboardRepository] Network exception: $e. Using local fallback.',
+      );
+      return _localFallback.getScores(event: event);
+    }
+  }
+
+  @override
+  Future<void> submitScore(LeaderboardEntryModel entry) async {
+    // Always persist to local storage as well
+    await _localFallback.submitScore(entry);
+
+    if (!isConfigured) return;
+
+    try {
+      final sanitizedUrl = supabaseUrl.endsWith('/')
+          ? supabaseUrl.substring(0, supabaseUrl.length - 1)
+          : supabaseUrl;
+      final uri = Uri.parse('$sanitizedUrl/rest/v1/leaderboard');
+
+      final payload = entry.toJson()..remove('id');
+
+      final response = await _httpClient
+          .post(
+            uri,
+            headers: {
+              'apikey': supabaseAnonKey,
+              'Authorization': 'Bearer $supabaseAnonKey',
+              'Content-Type': 'application/json',
+              'Prefer': 'return=minimal',
+            },
+            body: jsonEncode(payload),
+          )
+          .timeout(const Duration(seconds: 10));
+
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        debugPrint(
+          '[SupabaseLeaderboardRepository] Score recorded on Supabase: ${entry.playerName} -> ${entry.score}',
+        );
+      } else {
+        debugPrint(
+          '[SupabaseLeaderboardRepository] Error ${response.statusCode}: ${response.body}',
+        );
+      }
+    } catch (e) {
+      debugPrint('[SupabaseLeaderboardRepository] Network exception: $e');
+    }
+  }
+
+  @override
+  Future<List<String>> getEvents() async {
+    final scores = await getScores();
+    final events = <String>{};
+    for (final s in scores) {
+      if (s.event.trim().isNotEmpty) {
+        events.add(s.event.trim());
+      }
+    }
+    // Also include events from local fallback
+    final localEvents = await _localFallback.getEvents();
+    events.addAll(localEvents);
+
+    return events.toList()..sort();
+  }
+}

--- a/shorebird_runner/lib/features/leaderboard/data/supabase_leaderboard_repository.dart
+++ b/shorebird_runner/lib/features/leaderboard/data/supabase_leaderboard_repository.dart
@@ -78,7 +78,7 @@ class SupabaseLeaderboardRepository implements ILeaderboardRepository {
 
         // If remote is empty, fall back to local seed so new users see benchmark targets
         if (entries.isEmpty) {
-          return _localFallback.getScores(event: event);
+          return await _localFallback.getScores(event: event);
         }
 
         return entries;
@@ -86,13 +86,13 @@ class SupabaseLeaderboardRepository implements ILeaderboardRepository {
         debugPrint(
           '[SupabaseLeaderboardRepository] Status ${response.statusCode}: ${response.body}. Using local fallback.',
         );
-        return _localFallback.getScores(event: event);
+        return await _localFallback.getScores(event: event);
       }
     } catch (e) {
       debugPrint(
         '[SupabaseLeaderboardRepository] Network exception: $e. Using local fallback.',
       );
-      return _localFallback.getScores(event: event);
+      return await _localFallback.getScores(event: event);
     }
   }
 

--- a/shorebird_runner/lib/features/leaderboard/leaderboard.dart
+++ b/shorebird_runner/lib/features/leaderboard/leaderboard.dart
@@ -1,0 +1,4 @@
+export 'bloc/leaderboard_bloc.dart';
+export 'data/data.dart';
+export 'models/leaderboard_entry_model.dart';
+export 'widgets/leaderboard_dialog.dart';

--- a/shorebird_runner/lib/features/leaderboard/models/leaderboard_entry_model.dart
+++ b/shorebird_runner/lib/features/leaderboard/models/leaderboard_entry_model.dart
@@ -1,0 +1,63 @@
+import 'package:equatable/equatable.dart';
+
+/// Represents a single recorded score entry on the leaderboard.
+class LeaderboardEntryModel extends Equatable {
+  final int? id;
+  final String playerName;
+  final int score;
+  final int patches;
+  final String organization;
+  final String event;
+  final DateTime createdAt;
+
+  const LeaderboardEntryModel({
+    this.id,
+    required this.playerName,
+    required this.score,
+    this.patches = 0,
+    this.organization = '',
+    this.event = '',
+    required this.createdAt,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (id != null) 'id': id,
+      'player_name': playerName.trim(),
+      'score': score,
+      'patches': patches,
+      'organization': organization.trim(),
+      'event': event.trim(),
+      'created_at': createdAt.toUtc().toIso8601String(),
+    };
+  }
+
+  factory LeaderboardEntryModel.fromJson(Map<String, dynamic> json) {
+    return LeaderboardEntryModel(
+      id: json['id'] is int
+          ? json['id'] as int
+          : int.tryParse(json['id']?.toString() ?? ''),
+      playerName: (json['player_name'] as String?)?.trim() ??
+          (json['name'] as String?)?.trim() ??
+          'Anonymous Runner',
+      score: (json['score'] as num?)?.toInt() ?? 0,
+      patches: (json['patches'] as num?)?.toInt() ?? 0,
+      organization: (json['organization'] as String?)?.trim() ?? '',
+      event: (json['event'] as String?)?.trim() ?? '',
+      createdAt: json['created_at'] != null
+          ? DateTime.tryParse(json['created_at'].toString()) ?? DateTime.now()
+          : DateTime.now(),
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        playerName,
+        score,
+        patches,
+        organization,
+        event,
+        createdAt,
+      ];
+}

--- a/shorebird_runner/lib/features/leaderboard/widgets/leaderboard_dialog.dart
+++ b/shorebird_runner/lib/features/leaderboard/widgets/leaderboard_dialog.dart
@@ -1,0 +1,653 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shorebird_runner/core/constants/constants.dart';
+import 'package:shorebird_runner/features/leaderboard/bloc/leaderboard_bloc.dart';
+import 'package:shorebird_runner/features/leaderboard/models/leaderboard_entry_model.dart';
+
+/// Arcade-themed dialog displaying the global & event leaderboard.
+class LeaderboardDialog extends StatefulWidget {
+  final String? initialEvent;
+
+  const LeaderboardDialog({super.key, this.initialEvent});
+
+  static Future<void> show(
+    BuildContext context, {
+    String? initialEvent,
+  }) {
+    return showGeneralDialog(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Dismiss Leaderboard',
+      barrierColor: Colors.black.withValues(alpha: 0.8),
+      transitionDuration: const Duration(milliseconds: 280),
+      pageBuilder: (context, anim1, anim2) => LeaderboardDialog(
+        initialEvent: initialEvent,
+      ),
+      transitionBuilder: (context, anim1, anim2, child) {
+        final curved =
+            CurvedAnimation(parent: anim1, curve: Curves.easeOutCubic);
+        return ScaleTransition(
+          scale: Tween<double>(begin: 0.92, end: 1.0).animate(curved),
+          child: FadeTransition(
+            opacity: curved,
+            child: child,
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  State<LeaderboardDialog> createState() => _LeaderboardDialogState();
+}
+
+class _LeaderboardDialogState extends State<LeaderboardDialog> {
+  final TextEditingController _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    final bloc = context.read<LeaderboardBloc>();
+    bloc.add(FetchLeaderboard(initialEvent: widget.initialEvent));
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 580, maxHeight: 720),
+        child: Container(
+          decoration: BoxDecoration(
+            color: const Color(0xFF0D131F),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(
+              color: AppColors.shorebirdGold.withValues(alpha: 0.4),
+              width: 1.5,
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.shorebirdGold.withValues(alpha: 0.12),
+                blurRadius: 40,
+                spreadRadius: 2,
+                offset: const Offset(0, 8),
+              ),
+              const BoxShadow(
+                color: Colors.black87,
+                blurRadius: 48,
+                offset: Offset(0, 16),
+              ),
+            ],
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(24),
+            child: Column(
+              children: [
+                // Top Gold Accent Bar
+                Container(
+                  height: 4,
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [
+                        AppColors.goldAmber,
+                        AppColors.shorebirdGold,
+                        AppColors.goldPale,
+                        AppColors.shorebirdGold,
+                      ],
+                    ),
+                  ),
+                ),
+
+                // Dialog Header
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(24, 20, 20, 16),
+                  child: Row(
+                    children: [
+                      Container(
+                        padding: const EdgeInsets.all(10),
+                        decoration: BoxDecoration(
+                          color:
+                              AppColors.shorebirdGold.withValues(alpha: 0.15),
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color:
+                                AppColors.shorebirdGold.withValues(alpha: 0.5),
+                          ),
+                        ),
+                        child: const Icon(
+                          Icons.emoji_events_rounded,
+                          color: AppColors.shorebirdGold,
+                          size: 24,
+                        ),
+                      ),
+                      const SizedBox(width: 14),
+                      const Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'LEADERBOARD',
+                              style: TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.w900,
+                                color: AppColors.shorebirdGold,
+                                letterSpacing: 2.5,
+                              ),
+                            ),
+                            SizedBox(height: 2),
+                            Text(
+                              'Top OTA Deployers & Patch Champions',
+                              style: TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w500,
+                                color: AppColors.slateMuted,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        icon: const Icon(
+                          Icons.close_rounded,
+                          color: AppColors.slateMuted,
+                          size: 20,
+                        ),
+                        splashRadius: 20,
+                        onPressed: () => Navigator.of(context).pop(),
+                      ),
+                    ],
+                  ),
+                ),
+
+                const Divider(color: Color(0xFF1E293B), height: 1),
+
+                // Filter & Search Controls
+                BlocBuilder<LeaderboardBloc, LeaderboardState>(
+                  builder: (context, state) {
+                    return Padding(
+                      padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+                      child: Column(
+                        children: [
+                          // Search Box
+                          TextField(
+                            controller: _searchController,
+                            onChanged: (val) {
+                              context
+                                  .read<LeaderboardBloc>()
+                                  .add(SearchLeaderboard(val));
+                            },
+                            style: const TextStyle(
+                              color: Color(0xFFF1F5F9),
+                              fontSize: 14,
+                            ),
+                            decoration: InputDecoration(
+                              filled: true,
+                              fillColor: const Color(0xFF131C2E),
+                              hintText:
+                                  'Search by player, organization, or event...',
+                              hintStyle: const TextStyle(
+                                color: Color(0xFF475569),
+                                fontSize: 13,
+                              ),
+                              prefixIcon: const Icon(
+                                Icons.search_rounded,
+                                color: AppColors.slateMuted,
+                                size: 18,
+                              ),
+                              suffixIcon: _searchController.text.isNotEmpty
+                                  ? IconButton(
+                                      icon: const Icon(
+                                        Icons.clear_rounded,
+                                        color: AppColors.slateMuted,
+                                        size: 16,
+                                      ),
+                                      onPressed: () {
+                                        _searchController.clear();
+                                        context
+                                            .read<LeaderboardBloc>()
+                                            .add(const SearchLeaderboard(''));
+                                      },
+                                    )
+                                  : null,
+                              isDense: true,
+                              contentPadding: const EdgeInsets.symmetric(
+                                horizontal: 14,
+                                vertical: 12,
+                              ),
+                              enabledBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: const BorderSide(
+                                  color: Color(0xFF1E293B),
+                                  width: 1.2,
+                                ),
+                              ),
+                              focusedBorder: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                                borderSide: const BorderSide(
+                                  color: AppColors.shorebirdGold,
+                                  width: 1.5,
+                                ),
+                              ),
+                            ),
+                          ),
+
+                          const SizedBox(height: 12),
+
+                          // Event Filter Selector
+                          Row(
+                            children: [
+                              const Icon(
+                                Icons.filter_alt_outlined,
+                                size: 16,
+                                color: AppColors.slateMuted,
+                              ),
+                              const SizedBox(width: 8),
+                              const Text(
+                                'EVENT:',
+                                style: TextStyle(
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.w800,
+                                  color: AppColors.slateMuted,
+                                  letterSpacing: 1.0,
+                                ),
+                              ),
+                              const SizedBox(width: 10),
+                              Expanded(
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 12,
+                                    vertical: 4,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: const Color(0xFF131C2E),
+                                    borderRadius: BorderRadius.circular(10),
+                                    border: Border.all(
+                                      color: const Color(0xFF1E293B),
+                                    ),
+                                  ),
+                                  child: DropdownButtonHideUnderline(
+                                    child: DropdownButton<String>(
+                                      value: state.availableEvents
+                                              .contains(state.selectedEvent)
+                                          ? state.selectedEvent
+                                          : 'All Events',
+                                      isDense: true,
+                                      isExpanded: true,
+                                      dropdownColor: const Color(0xFF131C2E),
+                                      icon: const Icon(
+                                        Icons.keyboard_arrow_down_rounded,
+                                        color: AppColors.shorebirdGold,
+                                        size: 18,
+                                      ),
+                                      style: const TextStyle(
+                                        color: Color(0xFFF1F5F9),
+                                        fontSize: 13,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                      items: state.availableEvents
+                                          .map(
+                                            (e) => DropdownMenuItem(
+                                              value: e,
+                                              child: Text(
+                                                e.toUpperCase(),
+                                                style: TextStyle(
+                                                  color: e ==
+                                                          state.selectedEvent
+                                                      ? AppColors.shorebirdGold
+                                                      : const Color(0xFFCBD5E1),
+                                                  fontSize: 12,
+                                                  fontWeight: FontWeight.w700,
+                                                ),
+                                              ),
+                                            ),
+                                          )
+                                          .toList(),
+                                      onChanged: (val) {
+                                        if (val != null) {
+                                          context.read<LeaderboardBloc>().add(
+                                                FilterLeaderboardByEvent(val),
+                                              );
+                                        }
+                                      },
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+
+                const Divider(color: Color(0xFF1E293B), height: 1),
+
+                // Table Header
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+                  child: Row(
+                    children: [
+                      SizedBox(
+                        width: 44,
+                        child: Text(
+                          'RANK',
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w800,
+                            color: AppColors.slateMuted,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Text(
+                          'PLAYER / ORGANIZATION',
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w800,
+                            color: AppColors.slateMuted,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                      ),
+                      SizedBox(
+                        width: 90,
+                        child: Text(
+                          'SCORE',
+                          textAlign: TextAlign.right,
+                          style: TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.w800,
+                            color: AppColors.slateMuted,
+                            letterSpacing: 1.2,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                const Divider(color: Color(0xFF1A2234), height: 1),
+
+                // Leaderboard List
+                Expanded(
+                  child: BlocBuilder<LeaderboardBloc, LeaderboardState>(
+                    builder: (context, state) {
+                      if (state.status == LeaderboardStatus.loading &&
+                          state.allEntries.isEmpty) {
+                        return const Center(
+                          child: CircularProgressIndicator(
+                            color: AppColors.shorebirdGold,
+                            strokeWidth: 2.5,
+                          ),
+                        );
+                      }
+
+                      final entries = state.filteredEntries;
+
+                      if (entries.isEmpty) {
+                        return Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const Icon(
+                                Icons.search_off_rounded,
+                                size: 40,
+                                color: AppColors.slateMuted,
+                              ),
+                              const SizedBox(height: 12),
+                              const Text(
+                                'No runners found',
+                                style: TextStyle(
+                                  color: Color(0xFFCBD5E1),
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                state.searchQuery.isNotEmpty
+                                    ? 'No results matching "${state.searchQuery}"'
+                                    : 'Be the first to set a high score in this event!',
+                                style: const TextStyle(
+                                  color: AppColors.slateMuted,
+                                  fontSize: 12,
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                      }
+
+                      return ListView.separated(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                        itemCount: entries.length,
+                        separatorBuilder: (context, i) =>
+                            const SizedBox(height: 6),
+                        itemBuilder: (context, index) {
+                          final entry = entries[index];
+                          final rank = index + 1;
+                          return _LeaderboardRow(rank: rank, entry: entry);
+                        },
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LeaderboardRow extends StatelessWidget {
+  final int rank;
+  final LeaderboardEntryModel entry;
+
+  const _LeaderboardRow({
+    required this.rank,
+    required this.entry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Color rankColor;
+    Color? rankBg;
+    Widget? rankIcon;
+
+    if (rank == 1) {
+      rankColor = const Color(0xFFFFD700);
+      rankBg = const Color(0xFFFFD700).withValues(alpha: 0.15);
+      rankIcon = const Icon(
+        Icons.workspace_premium_rounded,
+        color: Color(0xFFFFD700),
+        size: 16,
+      );
+    } else if (rank == 2) {
+      rankColor = const Color(0xFFE2E8F0);
+      rankBg = const Color(0xFFE2E8F0).withValues(alpha: 0.12);
+      rankIcon = const Icon(
+        Icons.military_tech_rounded,
+        color: Color(0xFFCBD5E1),
+        size: 16,
+      );
+    } else if (rank == 3) {
+      rankColor = const Color(0xFFCD7F32);
+      rankBg = const Color(0xFFCD7F32).withValues(alpha: 0.15);
+      rankIcon = const Icon(
+        Icons.military_tech_outlined,
+        color: Color(0xFFCD7F32),
+        size: 16,
+      );
+    } else {
+      rankColor = AppColors.slateMuted;
+      rankBg = Colors.transparent;
+    }
+
+    final isTopThree = rank <= 3;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: isTopThree
+            ? rankColor.withValues(alpha: 0.06)
+            : const Color(0xFF101726),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isTopThree
+              ? rankColor.withValues(alpha: 0.3)
+              : const Color(0xFF1A2333),
+          width: isTopThree ? 1.2 : 1.0,
+        ),
+      ),
+      child: Row(
+        children: [
+          // Rank Badge
+          Container(
+            width: 36,
+            height: 32,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: rankBg,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (rankIcon != null) ...[
+                  rankIcon,
+                  const SizedBox(width: 2),
+                ],
+                Text(
+                  '$rank',
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w900,
+                    color: rankColor,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+
+          // Player Name & Organization / Event Tag
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  entry.playerName,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w700,
+                    color: Color(0xFFF8FAFC),
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Row(
+                  children: [
+                    if (entry.organization.isNotEmpty) ...[
+                      Text(
+                        entry.organization,
+                        style: const TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w500,
+                          color: AppColors.slateMuted,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(width: 6),
+                      Container(
+                        width: 3,
+                        height: 3,
+                        decoration: const BoxDecoration(
+                          color: AppColors.slateMuted,
+                          shape: BoxShape.circle,
+                        ),
+                      ),
+                      const SizedBox(width: 6),
+                    ],
+                    if (entry.event.isNotEmpty)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 1,
+                        ),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF1E293B),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          entry.event.toUpperCase(),
+                          style: const TextStyle(
+                            fontSize: 9,
+                            fontWeight: FontWeight.w700,
+                            color: Color(0xFF94A3B8),
+                            letterSpacing: 0.4,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          // Score & Patches Count
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                '${entry.score}',
+                style: const TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w900,
+                  color: AppColors.shorebirdGold,
+                  letterSpacing: 0.5,
+                ),
+              ),
+              if (entry.patches > 0)
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Text(
+                      '🐤',
+                      style: TextStyle(fontSize: 10),
+                    ),
+                    const SizedBox(width: 2),
+                    Text(
+                      '${entry.patches}',
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w600,
+                        color: AppColors.slateMuted,
+                      ),
+                    ),
+                  ],
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/shorebird_runner/lib/features/solo_runner/screens/solo_runner_screen.dart
+++ b/shorebird_runner/lib/features/solo_runner/screens/solo_runner_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shorebird_runner/core/core.dart';
 import 'package:shorebird_runner/features/lead_capture/models/lead_model.dart';
+import 'package:shorebird_runner/features/leaderboard/leaderboard.dart';
 import 'package:shorebird_runner/features/solo_runner/bloc/solo_runner_bloc.dart';
 import 'package:shorebird_runner/features/solo_runner/widgets/widgets.dart';
 import 'package:shorebird_runner/game/game.dart';
@@ -43,6 +44,20 @@ class _SoloRunnerScreenState extends State<SoloRunnerScreen> {
         context.read<SoloRunnerBloc>().add(
               SoloGameOver(score: score, patches: patches, level: level),
             );
+
+        if (score > 0) {
+          final lead = widget.lead;
+          final entry = LeaderboardEntryModel(
+            playerName:
+                lead?.name.isNotEmpty == true ? lead!.name : 'Anonymous Runner',
+            score: score,
+            patches: patches,
+            organization: lead?.organization ?? '',
+            event: lead?.event ?? '',
+            createdAt: DateTime.now(),
+          );
+          context.read<LeaderboardBloc>().add(RecordScore(entry));
+        }
       },
     );
   }

--- a/shorebird_runner/lib/features/solo_runner/widgets/game_over_overlay.dart
+++ b/shorebird_runner/lib/features/solo_runner/widgets/game_over_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shorebird_runner/core/core.dart';
+import 'package:shorebird_runner/features/leaderboard/leaderboard.dart';
 import 'package:shorebird_runner/features/solo_runner/widgets/stat_tile.dart';
 import 'package:shorebird_runner/game/game.dart';
 
@@ -131,6 +132,42 @@ class GameOverOverlay extends StatelessWidget {
                       fontWeight: FontWeight.w900,
                       letterSpacing: 1.5,
                     ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                OutlinedButton(
+                  onPressed: () {
+                    AudioService.playSelect();
+                    LeaderboardDialog.show(context);
+                  },
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppColors.shorebirdGold,
+                    side: BorderSide(
+                      color: AppColors.shorebirdGold.withValues(alpha: 0.4),
+                    ),
+                    minimumSize: const Size.fromHeight(46),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.emoji_events_rounded,
+                        size: 18,
+                        color: AppColors.shorebirdGold,
+                      ),
+                      SizedBox(width: 8),
+                      Text(
+                        'VIEW LEADERBOARD',
+                        style: TextStyle(
+                          fontSize: 13,
+                          fontWeight: FontWeight.w800,
+                          letterSpacing: 1.5,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: 10),

--- a/shorebird_runner/lib/features/start_menu/screens/start_screen.dart
+++ b/shorebird_runner/lib/features/start_menu/screens/start_screen.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shorebird_runner/core/constants/constants.dart';
-import 'package:shorebird_runner/features/lead_capture/bloc/bloc.dart';
-import 'package:shorebird_runner/features/lead_capture/models/lead_model.dart';
-import 'package:shorebird_runner/features/lead_capture/widgets/widgets.dart';
+import 'package:shorebird_runner/features/leaderboard/leaderboard.dart';
+import 'package:shorebird_runner/features/lead_capture/lead_capture.dart';
 import 'package:shorebird_runner/features/start_menu/widgets/widgets.dart';
 
 /// Full Shorebird-branded start screen with obsidian theme,
@@ -315,10 +314,31 @@ class _StartScreenState extends State<StartScreen>
                                   children: [
                                     Expanded(
                                       child: StartMenuSecondaryButton(
+                                        icon: Icons.emoji_events_rounded,
+                                        title: 'LEADERBOARD',
+                                        subtitle: 'TOP SCORES · RANKS',
+                                        color: AppColors.shorebirdGold,
+                                        onTap: () {
+                                          final activeEvent = context
+                                              .read<LeadCaptureBloc>()
+                                              .state
+                                              .event;
+                                          LeaderboardDialog.show(
+                                            context,
+                                            initialEvent: activeEvent.isNotEmpty
+                                                ? activeEvent
+                                                : null,
+                                          );
+                                        },
+                                      ),
+                                    ),
+                                    const SizedBox(width: 10),
+                                    Expanded(
+                                      child: StartMenuSecondaryButton(
                                         icon: Icons.menu_book_rounded,
                                         title: 'HOW TO PLAY',
                                         subtitle: 'RULES · TIERS · CONTROLS',
-                                        color: AppColors.shorebirdGold,
+                                        color: const Color(0xFF38BDF8),
                                         onTap: () => showGameRulesDialog(
                                           context,
                                           onStart: _onStartPressed,

--- a/shorebird_runner/lib/main.dart
+++ b/shorebird_runner/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:shorebird_runner/core/core.dart';
 import 'package:shorebird_runner/features/app_shell/bloc/app_shell_bloc.dart';
 import 'package:shorebird_runner/features/app_shell/screens/app_shell_screen.dart';
 import 'package:shorebird_runner/features/lead_capture/lead_capture.dart';
+import 'package:shorebird_runner/features/leaderboard/leaderboard.dart';
 import 'package:shorebird_runner/features/solo_runner/bloc/solo_runner_bloc.dart';
 import 'package:shorebird_runner/features/start_menu/bloc/start_menu_bloc.dart';
 
@@ -25,11 +26,15 @@ class PatchRushApp extends StatelessWidget {
         RepositoryProvider<ILeadRepository>(
           create: (_) => SupabaseLeadRepository(),
         ),
+        RepositoryProvider<ILeaderboardRepository>(
+          create: (_) => SupabaseLeaderboardRepository(),
+        ),
       ],
       child: Builder(
         builder: (context) {
           final highScoreRepo = context.read<IHighScoreRepository>();
           final leadRepo = context.read<ILeadRepository>();
+          final leaderboardRepo = context.read<ILeaderboardRepository>();
 
           return MultiBlocProvider(
             providers: [
@@ -45,6 +50,9 @@ class PatchRushApp extends StatelessWidget {
               ),
               BlocProvider<StartMenuBloc>(
                 create: (_) => StartMenuBloc(),
+              ),
+              BlocProvider<LeaderboardBloc>(
+                create: (_) => LeaderboardBloc(repository: leaderboardRepo),
               ),
             ],
             child: MaterialApp(

--- a/shorebird_runner/pubspec.lock
+++ b/shorebird_runner/pubspec.lock
@@ -172,10 +172,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   nested:
     dependency: transitive
     description:
@@ -369,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   typed_data:
     dependency: transitive
     description:
@@ -385,10 +385,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:

--- a/shorebird_runner/test/lead_capture_test.dart
+++ b/shorebird_runner/test/lead_capture_test.dart
@@ -151,5 +151,37 @@ void main() {
         ),
       );
     });
+
+    test('validates and submits successfully when phone number is omitted',
+        () async {
+      bloc.add(const LeadNameChanged('Katherine Johnson'));
+      bloc.add(const LeadEmailChanged('katherine@nasa.gov'));
+      // Phone left empty
+      bloc.add(const LeadPhoneChanged(''));
+      bloc.add(const LeadOrgChanged('NASA'));
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeadCaptureState>(
+            (state) => state.isValid && state.phone.isEmpty,
+          ),
+        ),
+      );
+
+      bloc.add(const LeadSubmitted());
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeadCaptureState>(
+            (state) =>
+                state.status == LeadSubmissionStatus.success &&
+                state.submittedLead?.name == 'Katherine Johnson' &&
+                state.submittedLead?.phone == '',
+          ),
+        ),
+      );
+    });
   });
 }

--- a/shorebird_runner/test/leaderboard_test.dart
+++ b/shorebird_runner/test/leaderboard_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shorebird_runner/features/leaderboard/leaderboard.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LeaderboardEntryModel', () {
+    test('toJson and fromJson work symmetrically', () {
+      final now = DateTime.now();
+      final entry = LeaderboardEntryModel(
+        id: 42,
+        playerName: 'Abhishek Doshi',
+        score: 4500,
+        patches: 72,
+        organization: 'Shorebird',
+        event: 'Droidcon London',
+        createdAt: now,
+      );
+
+      final json = entry.toJson();
+      expect(json['id'], 42);
+      expect(json['player_name'], 'Abhishek Doshi');
+      expect(json['score'], 4500);
+      expect(json['patches'], 72);
+      expect(json['organization'], 'Shorebird');
+      expect(json['event'], 'Droidcon London');
+
+      final parsed = LeaderboardEntryModel.fromJson(json);
+      expect(parsed.id, 42);
+      expect(parsed.playerName, 'Abhishek Doshi');
+      expect(parsed.score, 4500);
+      expect(parsed.patches, 72);
+      expect(parsed.organization, 'Shorebird');
+      expect(parsed.event, 'Droidcon London');
+    });
+  });
+
+  group('LocalLeaderboardRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('retrieves seeded benchmark scores on initial run', () async {
+      const repo = LocalLeaderboardRepository();
+      final scores = await repo.getScores();
+
+      expect(scores, isNotEmpty);
+      expect(scores.first.score, greaterThan(0));
+      // Verify sorted descending
+      for (int i = 0; i < scores.length - 1; i++) {
+        expect(scores[i].score, greaterThanOrEqualTo(scores[i + 1].score));
+      }
+    });
+
+    test('filters scores by event', () async {
+      const repo = LocalLeaderboardRepository();
+      final droidconScores = await repo.getScores(event: 'Droidcon London');
+
+      expect(droidconScores, isNotEmpty);
+      for (final s in droidconScores) {
+        expect(s.event.toLowerCase(), 'droidcon london');
+      }
+    });
+
+    test('submits new score and preserves ranking order', () async {
+      const repo = LocalLeaderboardRepository();
+      final newChamp = LeaderboardEntryModel(
+        playerName: 'Top Player',
+        score: 99999,
+        patches: 200,
+        organization: 'Shorebird HighFlyers',
+        event: 'Droidcon London',
+        createdAt: DateTime.now(),
+      );
+
+      await repo.submitScore(newChamp);
+      final scores = await repo.getScores();
+
+      expect(scores.first.playerName, 'Top Player');
+      expect(scores.first.score, 99999);
+    });
+
+    test('extracts distinct events', () async {
+      const repo = LocalLeaderboardRepository();
+      final events = await repo.getEvents();
+
+      expect(events, contains('Droidcon London'));
+      expect(events, contains('FlutterCon'));
+      expect(events, contains('Global'));
+    });
+  });
+
+  group('LeaderboardBloc', () {
+    late LocalLeaderboardRepository repo;
+    late LeaderboardBloc bloc;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      repo = const LocalLeaderboardRepository();
+      bloc = LeaderboardBloc(repository: repo);
+    });
+
+    tearDown(() {
+      bloc.close();
+    });
+
+    test('fetches leaderboard scores and populates state', () async {
+      bloc.add(const FetchLeaderboard());
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeaderboardState>(
+            (state) =>
+                state.status == LeaderboardStatus.success &&
+                state.allEntries.isNotEmpty &&
+                state.filteredEntries.isNotEmpty &&
+                state.availableEvents.contains('All Events'),
+          ),
+        ),
+      );
+    });
+
+    test('filters leaderboard by event', () async {
+      bloc.add(const FetchLeaderboard());
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeaderboardState>(
+            (state) => state.status == LeaderboardStatus.success,
+          ),
+        ),
+      );
+
+      bloc.add(const FilterLeaderboardByEvent('FlutterCon'));
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeaderboardState>(
+            (state) =>
+                state.selectedEvent == 'FlutterCon' &&
+                state.filteredEntries.every(
+                  (e) => e.event.toLowerCase() == 'fluttercon',
+                ),
+          ),
+        ),
+      );
+    });
+
+    test('searches leaderboard by player name or organization', () async {
+      bloc.add(const FetchLeaderboard());
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeaderboardState>(
+            (state) => state.status == LeaderboardStatus.success,
+          ),
+        ),
+      );
+
+      bloc.add(const SearchLeaderboard('Sarah'));
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(
+          predicate<LeaderboardState>(
+            (state) =>
+                state.searchQuery == 'Sarah' &&
+                state.filteredEntries.every(
+                  (e) =>
+                      e.playerName.contains('Sarah') ||
+                      e.organization.contains('Sarah'),
+                ),
+          ),
+        ),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Optional Contact Number**: Updated `LeadCaptureState` and `LeadCaptureDialog` so the phone number is explicitly optional while still validated if provided.
- **In-Game Leaderboard**:
  - **Data Layer**: Added `LeaderboardEntryModel`, `ILeaderboardRepository`, `SupabaseLeaderboardRepository` (PostgREST integration with live database table), and `LocalLeaderboardRepository` with offline fallback.
  - **State Management**: Added `LeaderboardBloc` with support for fetching top scores, filtering by event ("All Events", active event, specific conferences), and live text searching across player name, organization, and event.
  - **UI**: Added `LeaderboardDialog` with obsidian glass theme, search bar, event dropdown filter, rank badges (#1 Gold, #2 Silver, #3 Bronze), and score/patch counts.
  - **Integration**: Added "LEADERBOARD" button to Start Screen and Game Over screen, and automatically records player runs on game over.
  - **Testing**: Added unit tests covering optional phone validation, leaderboard repository, model serialization, and BLoC filtering/search.